### PR TITLE
Add small screen interface, expose auto-scan, color, and Unicode settings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,7 @@ Keybindings can be customized in the config file `$HOME/.config/impala/config.to
 
 switch = "r"
 mode = "station"
+unicode = true
 
 [device]
 infos = "i"

--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,7 @@ Keybindings can be customized in the config file `$HOME/.config/impala/config.to
 switch = "r"
 mode = "station"
 color_mode = "auto"
+monochrome = false
 unicode = true
 small_layout_rows = 30
 small_layout_cols = 80

--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,7 @@ Keybindings can be customized in the config file `$HOME/.config/impala/config.to
 
 switch = "r"
 mode = "station"
+color_mode = "auto"
 unicode = true
 
 [device]

--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ This will produce an executable file at `target/release/impala` that you can cop
 
 ### Global
 
-`Tab` or `Shift + Tab`: Switch between different sections.
+`Tab`, `Shift + Tab`, `Left`, `Right`, `h`, `l`: Switch between different sections.
 
 `j` or `Down` : Scroll down.
 

--- a/Readme.md
+++ b/Readme.md
@@ -105,7 +105,8 @@ switch = "r"
 mode = "station"
 color_mode = "auto"
 unicode = true
-narrow_cols = 80
+small_layout_rows = 30
+small_layout_cols = 80
 
 [device]
 infos = "i"

--- a/Readme.md
+++ b/Readme.md
@@ -115,6 +115,7 @@ stop = 'x'
 [station]
 toggle_scanning = "s"
 toggle_connect = " "
+auto_scan = true
 
 [station.known_network]
 toggle_autoconnect = "a"

--- a/Readme.md
+++ b/Readme.md
@@ -105,6 +105,7 @@ switch = "r"
 mode = "station"
 color_mode = "auto"
 unicode = true
+narrow_cols = 80
 
 [device]
 infos = "i"

--- a/Release.md
+++ b/Release.md
@@ -1,3 +1,12 @@
+## v0.3 - 2024-07-28
+
+### Added
+
+- Add tabbed interface variant for small screens.
+- Add config file settings for auto-scan, color mode, and Unicode/ASCII.
+- Fixes high CPU usage, 500us poll was hammering DBus and causing lag on Raspberry Pi.
+- Fixes terminal not resetting properly on exit.
+
 ## v0.2.1 - 2024-06-27
 
 ### Added

--- a/Release.md
+++ b/Release.md
@@ -3,7 +3,7 @@
 ### Added
 
 - Add tabbed interface variant for small screens.
-- Add config file settings for auto-scan, color mode, and Unicode/ASCII.
+- Add config file settings for auto-scan, color mode, narrow mode, and Unicode/ASCII.
 - Fixes high CPU usage, 500us poll was hammering DBus and causing lag on Raspberry Pi.
 - Fixes terminal not resetting properly on exit.
 

--- a/src/access_point.rs
+++ b/src/access_point.rs
@@ -7,7 +7,6 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
-    style::{Color, Style, Stylize},
     text::Text,
     widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
     Frame,
@@ -17,6 +16,7 @@ use crate::{
     app::AppResult,
     event::Event,
     notification::{Notification, NotificationLevel},
+    tui::Palette,
 };
 use tui_input::Input;
 
@@ -89,7 +89,7 @@ impl AccessPoint {
         })
     }
 
-    pub fn render_input(&self, frame: &mut Frame) {
+    pub fn render_input(&self, palette: &Palette, frame: &mut Frame) {
         let popup_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints(
@@ -173,23 +173,23 @@ impl AccessPoint {
 
         let ssid_msg = Paragraph::new(ssid_text)
             .alignment(Alignment::Left)
-            .style(Style::default().fg(Color::White))
+            .style(palette.text)
             .block(Block::new().padding(Padding::left(2)));
 
         let ssid_input = Paragraph::new(self.ssid.value())
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::White))
-            .block(Block::new().style(Style::default().bg(Color::DarkGray)));
+            .style(palette.input_text)
+            .block(Block::new().style(palette.input_box));
 
         let psk_msg = Paragraph::new(psk_text)
             .alignment(Alignment::Left)
-            .style(Style::default().fg(Color::White))
+            .style(palette.text)
             .block(Block::new().padding(Padding::left(2)));
 
         let psk_input = Paragraph::new(self.psk.value())
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::White))
-            .block(Block::new().style(Style::default().bg(Color::DarkGray)));
+            .style(palette.input_text)
+            .block(Block::new().style(palette.input_box));
 
         frame.render_widget(Clear, area);
 
@@ -197,8 +197,8 @@ impl AccessPoint {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .style(Style::default().green())
-                .border_style(Style::default().fg(Color::Green)),
+                .style(palette.text)
+                .border_style(palette.active_border),
             area,
         );
         frame.render_widget(ssid_msg, ssid_msg_area);

--- a/src/access_point.rs
+++ b/src/access_point.rs
@@ -90,6 +90,13 @@ impl AccessPoint {
     }
 
     pub fn render_input(&self, palette: &Palette, frame: &mut Frame) {
+
+        let width = if frame.size().width > 80 {
+            (frame.size().width - 80) / 2
+        } else {
+            frame.size().width
+        };
+
         let popup_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints(
@@ -106,9 +113,9 @@ impl AccessPoint {
             .direction(Direction::Horizontal)
             .constraints(
                 [
-                    Constraint::Length((frame.size().width - 80) / 2),
+                    Constraint::Length(width),
                     Constraint::Min(80),
-                    Constraint::Length((frame.size().width - 80) / 2),
+                    Constraint::Length(width),
                 ]
                 .as_ref(),
             )

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -100,7 +100,7 @@ impl Adapter {
             }
         }]);
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
 
         let widths = [
             Constraint::Length(8),
@@ -219,7 +219,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
 
         let widths = [
             Constraint::Length(8),
@@ -366,7 +366,7 @@ impl Adapter {
             ap_is_scanning,
         ]);
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
 
         let widths = [
             Constraint::Length(10),
@@ -525,7 +525,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
 
         let widths = [
             Constraint::Length(8),
@@ -672,7 +672,7 @@ impl Adapter {
 
         let row = Row::new(row);
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
 
         let widths = [
             Constraint::Length(12),
@@ -821,7 +821,7 @@ impl Adapter {
             })
             .collect();
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
 
         let widths = [
             Constraint::Length(1),
@@ -992,7 +992,7 @@ impl Adapter {
             })
             .collect();
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
 
         let widths = [
             Constraint::Length(15),
@@ -1097,7 +1097,7 @@ impl Adapter {
     }
 
     pub fn render_station_mode(&self, frame: &mut Frame, focused_block: FocusedBlock) {
-        if frame.size().height > self.config.small_layout_rows {
+        if frame.size().height > self.config.small_layout_height {
             let (device_block, station_block, known_networks_block, new_networks_block) = {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -102,6 +102,8 @@ impl Adapter {
             }
         }]);
 
+        let narrow_mode =  frame.size().width < 72;
+
         let widths = [
             Constraint::Length(8),
             Constraint::Length(8),
@@ -163,7 +165,7 @@ impl Adapter {
                         }
                     }),
             )
-            .column_spacing(3)
+            .column_spacing(if narrow_mode { 1 } else { 3 })
             .style(match self.config.color_mode {
                 ColorMode::Light => Style::default().fg(Color::Black),
                 _ => Style::default().fg(Color::White),
@@ -223,10 +225,12 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
+        let narrow_mode =  frame.size().width < 72;
+
         let widths = [
             Constraint::Length(8),
             Constraint::Length(12),
-            Constraint::Length(10),
+            Constraint::Length(9),
             Constraint::Fill(1),
         ];
 
@@ -290,7 +294,7 @@ impl Adapter {
                         }
                     }),
             )
-            .column_spacing(3)
+            .column_spacing(if narrow_mode { 1 } else { 3 })
             .style(match self.config.color_mode {
                 ColorMode::Light => Style::default().fg(Color::Black),
                 _ => Style::default().fg(Color::White),
@@ -368,6 +372,8 @@ impl Adapter {
             ap_is_scanning,
         ]);
 
+        let narrow_mode =  frame.size().width < 72;
+
         let widths = [
             Constraint::Length(10),
             Constraint::Length(15),
@@ -441,7 +447,7 @@ impl Adapter {
                         }
                     }),
             )
-            .column_spacing(3)
+            .column_spacing(if narrow_mode { 1 } else { 3 })
             .style(match self.config.color_mode {
                 ColorMode::Light => Style::default().fg(Color::Black),
                 _ => Style::default().fg(Color::White),
@@ -525,6 +531,8 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
+        let narrow_mode =  frame.size().width < 72;
+
         let widths = [
             Constraint::Length(8),
             Constraint::Length(8),
@@ -592,7 +600,7 @@ impl Adapter {
                         }
                     }),
             )
-            .column_spacing(3)
+            .column_spacing(if narrow_mode { 1 } else { 3 })
             .style(match self.config.color_mode {
                 ColorMode::Light => Style::default().fg(Color::Black),
                 _ => Style::default().fg(Color::White),
@@ -670,6 +678,8 @@ impl Adapter {
 
         let row = Row::new(row);
 
+        let narrow_mode =  frame.size().width < 72;
+
         let widths = [
             Constraint::Length(12),
             Constraint::Length(10),
@@ -737,7 +747,7 @@ impl Adapter {
                         }
                     }),
             )
-            .column_spacing(3)
+            .column_spacing(if narrow_mode { 1 } else { 3 })
             .style(match self.config.color_mode {
                 ColorMode::Light => Style::default().fg(Color::Black),
                 _ => Style::default().fg(Color::White),
@@ -782,7 +792,7 @@ impl Adapter {
             {
                 if connected_net.name == net.name {
                     let row = vec![
-                        Line::from("󰸞"),
+                        Line::from(if self.config.unicode { "󰸞" } else { "*" }),
                         Line::from(net.name.clone()),
                         Line::from(net.netowrk_type.clone()).centered(),
                         Line::from(net.is_hidden.to_string()),
@@ -818,12 +828,14 @@ impl Adapter {
         })
         .collect();
 
+        let narrow_mode =  frame.size().width < 72;
+
         let widths = [
-            Constraint::Length(2),
+            Constraint::Length(1),
             Constraint::Length(15),
             Constraint::Length(8),
             Constraint::Length(6),
-            Constraint::Length(12),
+            Constraint::Length(if narrow_mode { 7 } else { 12 }),
             Constraint::Length(6),
         ];
 
@@ -835,7 +847,8 @@ impl Adapter {
                         Cell::from("Name").style(Style::default().fg(Color::Yellow)),
                         Cell::from("Security").style(Style::default().fg(Color::Yellow)),
                         Cell::from("Hidden").style(Style::default().fg(Color::Yellow)),
-                        Cell::from("Auto Connect").style(Style::default().fg(Color::Yellow)),
+                        Cell::from(if narrow_mode { "AutoCon" } else { "Auto Connect" })
+                            .style(Style::default().fg(Color::Yellow)),
                         Cell::from("Signal").style(Style::default().fg(Color::Yellow)),
                     ])
                     .style(Style::new().bold())
@@ -894,7 +907,7 @@ impl Adapter {
                         }
                     }),
             )
-            .column_spacing(4)
+            .column_spacing(if narrow_mode { 1 } else { 4 })
             .style(match self.config.color_mode {
                 ColorMode::Light => Style::default().fg(Color::Black),
                 _ => Style::default().fg(Color::White),
@@ -944,21 +957,29 @@ impl Adapter {
                             2 * (100 + signal / 100)
                         }
                     };
-                    match signal {
-                        n if n >= 75 => format!("{:3}% 󰤨", signal),
-                        n if (50..75).contains(&n) => format!("{:3}% 󰤥", signal),
-                        n if (25..50).contains(&n) => format!("{:3}% 󰤢", signal),
-                        _ => format!("{:3}% 󰤟", signal),
-                    }
+
+                    let signal_level = match signal {
+                        n if n >= 75
+                            => if self.config.unicode { "󰤨" } else { "(****))" },
+                        n if (50..75).contains(&n)
+                            => if self.config.unicode { "󰤥" } else { "(*** )" },
+                        n if (25..50).contains(&n)
+                            => if self.config.unicode { "󰤢" } else { "(**  )" },
+                        _ => if self.config.unicode { "󰤟" } else { "(*   )" },
+                    };
+
+                    format!("{:3}% {}", signal, signal_level)
                 }),
             ])
         })
         .collect();
 
+        let narrow_mode =  frame.size().width < 72;
+
         let widths = [
             Constraint::Length(15),
             Constraint::Length(8),
-            Constraint::Length(6),
+            Constraint::Length(if self.config.unicode { 6 } else { 11 }),
         ];
 
         let new_networks_table = Table::new(rows, widths)
@@ -1016,7 +1037,7 @@ impl Adapter {
                         }
                     }),
             )
-            .column_spacing(4)
+            .column_spacing(if narrow_mode { 1 } else { 4 })
             .style(match self.config.color_mode {
                 ColorMode::Light => Style::default().fg(Color::Black),
                 _ => Style::default().fg(Color::White),

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -7,14 +7,16 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Style, Stylize},
     text::Line,
-    widgets::{Block, BorderType, Borders, Cell, Clear, List, Padding, Row, Table,
-        TableState, Tabs, Paragraph},
+    widgets::{
+        Block, BorderType, Borders, Cell, Clear, List, Padding, Paragraph, Row, Table, TableState,
+        Tabs,
+    },
     Frame,
 };
 
 use crate::{
-    config::{Config, ColorMode},
     app::FocusedBlock,
+    config::{ColorMode, Config},
     device::Device,
 };
 
@@ -79,11 +81,7 @@ impl Adapter {
         }
     }
 
-    pub fn render_other_mode(
-        &self,
-        frame: &mut Frame,
-        focused_block: FocusedBlock,
-    ) {
+    pub fn render_other_mode(&self, frame: &mut Frame, focused_block: FocusedBlock) {
         let device_block = {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -102,7 +100,7 @@ impl Adapter {
             }
         }]);
 
-        let narrow_mode =  frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -180,11 +178,7 @@ impl Adapter {
         frame.render_stateful_widget(device_table, device_block, &mut device_state);
     }
 
-    pub fn render_access_point_mode(
-        &self,
-        frame: &mut Frame,
-        focused_block: FocusedBlock,
-    ) {
+    pub fn render_access_point_mode(&self, frame: &mut Frame, focused_block: FocusedBlock) {
         let any_connected_devices = match self.device.access_point.as_ref() {
             Some(ap) => !ap.connected_devices.is_empty(),
             None => false,
@@ -225,7 +219,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode =  frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -372,7 +366,7 @@ impl Adapter {
             ap_is_scanning,
         ]);
 
-        let narrow_mode =  frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(10),
@@ -531,7 +525,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode =  frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -678,7 +672,7 @@ impl Adapter {
 
         let row = Row::new(row);
 
-        let narrow_mode =  frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(12),
@@ -769,66 +763,65 @@ impl Adapter {
         render_title: bool,
         is_focused: bool,
     ) {
-
         let rows: Vec<Row> = self
-        .device
-        .station
-        .as_ref()
-        .unwrap()
-        .known_networks
-        .iter()
-        .map(|(net, signal)| {
-            let net = net.known_network.as_ref().unwrap();
-            let signal = format!("{}%", {
-                if *signal / 100 >= -50 {
-                    100
-                } else {
-                    2 * (100 + signal / 100)
-                }
-            });
+            .device
+            .station
+            .as_ref()
+            .unwrap()
+            .known_networks
+            .iter()
+            .map(|(net, signal)| {
+                let net = net.known_network.as_ref().unwrap();
+                let signal = format!("{}%", {
+                    if *signal / 100 >= -50 {
+                        100
+                    } else {
+                        2 * (100 + signal / 100)
+                    }
+                });
 
-            if let Some(connected_net) =
-                &self.device.station.as_ref().unwrap().connected_network
-            {
-                if connected_net.name == net.name {
-                    let row = vec![
-                        Line::from(if self.config.unicode { "󰸞" } else { "*" }),
-                        Line::from(net.name.clone()),
-                        Line::from(net.netowrk_type.clone()).centered(),
-                        Line::from(net.is_hidden.to_string()),
-                        Line::from(net.is_autoconnect.to_string()).centered(),
-                        Line::from(signal).centered(),
-                    ];
+                if let Some(connected_net) =
+                    &self.device.station.as_ref().unwrap().connected_network
+                {
+                    if connected_net.name == net.name {
+                        let row = vec![
+                            Line::from(if self.config.unicode { "󰸞" } else { "*" }),
+                            Line::from(net.name.clone()),
+                            Line::from(net.netowrk_type.clone()).centered(),
+                            Line::from(net.is_hidden.to_string()),
+                            Line::from(net.is_autoconnect.to_string()).centered(),
+                            Line::from(signal).centered(),
+                        ];
 
-                    Row::new(row)
+                        Row::new(row)
+                    } else {
+                        let row = vec![
+                            Line::from(""),
+                            Line::from(net.name.clone()),
+                            Line::from(net.netowrk_type.clone()).centered(),
+                            Line::from(net.is_hidden.to_string()),
+                            Line::from(net.is_autoconnect.to_string()).centered(),
+                            Line::from(signal).centered(),
+                        ];
+
+                        Row::new(row)
+                    }
                 } else {
                     let row = vec![
                         Line::from(""),
                         Line::from(net.name.clone()),
                         Line::from(net.netowrk_type.clone()).centered(),
                         Line::from(net.is_hidden.to_string()),
-                        Line::from(net.is_autoconnect.to_string()).centered(),
+                        Line::from(net.is_autoconnect.to_string()),
                         Line::from(signal).centered(),
                     ];
 
                     Row::new(row)
                 }
-            } else {
-                let row = vec![
-                    Line::from(""),
-                    Line::from(net.name.clone()),
-                    Line::from(net.netowrk_type.clone()).centered(),
-                    Line::from(net.is_hidden.to_string()),
-                    Line::from(net.is_autoconnect.to_string()),
-                    Line::from(signal).centered(),
-                ];
+            })
+            .collect();
 
-                Row::new(row)
-            }
-        })
-        .collect();
-
-        let narrow_mode =  frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(1),
@@ -847,8 +840,12 @@ impl Adapter {
                         Cell::from("Name").style(Style::default().fg(Color::Yellow)),
                         Cell::from("Security").style(Style::default().fg(Color::Yellow)),
                         Cell::from("Hidden").style(Style::default().fg(Color::Yellow)),
-                        Cell::from(if narrow_mode { "AutoCon" } else { "Auto Connect" })
-                            .style(Style::default().fg(Color::Yellow)),
+                        Cell::from(if narrow_mode {
+                            "AutoCon"
+                        } else {
+                            "Auto Connect"
+                        })
+                        .style(Style::default().fg(Color::Yellow)),
                         Cell::from("Signal").style(Style::default().fg(Color::Yellow)),
                     ])
                     .style(Style::new().bold())
@@ -939,42 +936,63 @@ impl Adapter {
         is_focused: bool,
     ) {
         let rows: Vec<Row> = self
-        .device
-        .station
-        .as_ref()
-        .unwrap()
-        .new_networks
-        .iter()
-        .map(|(net, signal)| {
-            Row::new(vec![
-                Line::from(net.name.clone()),
-                Line::from(net.netowrk_type.clone()).centered(),
-                Line::from({
-                    let signal = {
-                        if *signal / 100 >= -50 {
-                            100
-                        } else {
-                            2 * (100 + signal / 100)
-                        }
-                    };
+            .device
+            .station
+            .as_ref()
+            .unwrap()
+            .new_networks
+            .iter()
+            .map(|(net, signal)| {
+                Row::new(vec![
+                    Line::from(net.name.clone()),
+                    Line::from(net.netowrk_type.clone()).centered(),
+                    Line::from({
+                        let signal = {
+                            if *signal / 100 >= -50 {
+                                100
+                            } else {
+                                2 * (100 + signal / 100)
+                            }
+                        };
 
-                    let signal_level = match signal {
-                        n if n >= 75
-                            => if self.config.unicode { "󰤨" } else { "(****))" },
-                        n if (50..75).contains(&n)
-                            => if self.config.unicode { "󰤥" } else { "(*** )" },
-                        n if (25..50).contains(&n)
-                            => if self.config.unicode { "󰤢" } else { "(**  )" },
-                        _ => if self.config.unicode { "󰤟" } else { "(*   )" },
-                    };
+                        let signal_level = match signal {
+                            n if n >= 75 => {
+                                if self.config.unicode {
+                                    "󰤨"
+                                } else {
+                                    "(****))"
+                                }
+                            }
+                            n if (50..75).contains(&n) => {
+                                if self.config.unicode {
+                                    "󰤥"
+                                } else {
+                                    "(*** )"
+                                }
+                            }
+                            n if (25..50).contains(&n) => {
+                                if self.config.unicode {
+                                    "󰤢"
+                                } else {
+                                    "(**  )"
+                                }
+                            }
+                            _ => {
+                                if self.config.unicode {
+                                    "󰤟"
+                                } else {
+                                    "(*   )"
+                                }
+                            }
+                        };
 
-                    format!("{:3}% {}", signal, signal_level)
-                }),
-            ])
-        })
-        .collect();
+                        format!("{:3}% {}", signal, signal_level)
+                    }),
+                ])
+            })
+            .collect();
 
-        let narrow_mode =  frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(15),
@@ -1062,30 +1080,24 @@ impl Adapter {
     }
 
     pub fn render_status_bar(&self, frame: &mut Frame, status_bar_block: Rect) {
-        let status_bar_content = Paragraph::new(format!(
-            "Q: quit Arrows/HJKL: move Space: connect ?: help"
-        ))
-        .style(Style::default()
-            .fg(match self.config.color_mode {
-                ColorMode::Light => Color::White,
-                _ => Color::Black
-            })
-            .bg(match self.config.color_mode {
-                ColorMode::Light => Color::Black,
-                _ => Color::White
-            })
-        );
+        let status_bar_content = Paragraph::new("Q: quit Arrows/HJKL: move Space: connect ?: help")
+            .style(
+                Style::default()
+                    .fg(match self.config.color_mode {
+                        ColorMode::Light => Color::White,
+                        _ => Color::Black,
+                    })
+                    .bg(match self.config.color_mode {
+                        ColorMode::Light => Color::Black,
+                        _ => Color::White,
+                    }),
+            );
 
         frame.render_widget(status_bar_content, status_bar_block);
     }
 
-    pub fn render_station_mode(
-        &self,
-        frame: &mut Frame,
-        focused_block: FocusedBlock,
-    ) {
+    pub fn render_station_mode(&self, frame: &mut Frame, focused_block: FocusedBlock) {
         if frame.size().height > 30 {
-
             let (device_block, station_block, known_networks_block, new_networks_block) = {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)
@@ -1101,42 +1113,61 @@ impl Adapter {
             };
 
             // Device
-            self.render_device_table(frame, device_block,
-                true /* render title */,
-                focused_block == FocusedBlock::Device);
+            self.render_device_table(
+                frame,
+                device_block,
+                true, /* render title */
+                focused_block == FocusedBlock::Device,
+            );
 
             // Station
-            self.render_station_table(frame, station_block,
-                true /* render title */,
-                focused_block == FocusedBlock::Station);
+            self.render_station_table(
+                frame,
+                station_block,
+                true, /* render title */
+                focused_block == FocusedBlock::Station,
+            );
 
             // Known networks
-            self.render_known_networks_table(frame, known_networks_block,
-                true /* render title */,
-                focused_block == FocusedBlock::KnownNetworks);
+            self.render_known_networks_table(
+                frame,
+                known_networks_block,
+                true, /* render title */
+                focused_block == FocusedBlock::KnownNetworks,
+            );
 
             // New networks
-            self.render_new_networks_table(frame, new_networks_block,
-                true /* render title */,
-                focused_block == FocusedBlock::NewNetworks);
+            self.render_new_networks_table(
+                frame,
+                new_networks_block,
+                true, /* render title */
+                focused_block == FocusedBlock::NewNetworks,
+            );
 
         // Render compact tabs view
         } else {
             let (tab_bar_block, content_block, status_bar_block) = {
                 let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(1),
-                    Constraint::Min(0),
-                    Constraint::Length(1),
-                ].as_ref())
-                .split(frame.size());
+                    .direction(Direction::Vertical)
+                    .constraints(
+                        [
+                            Constraint::Length(1),
+                            Constraint::Min(0),
+                            Constraint::Length(1),
+                        ]
+                        .as_ref(),
+                    )
+                    .split(frame.size());
                 (chunks[0], chunks[1], chunks[2])
             };
 
             // Differentiate selected tab with ASCII
-            fn format_tab_title(unicode: bool, focused_block: FocusedBlock,
-                title_block: FocusedBlock, title: &str) -> String {
+            fn format_tab_title(
+                unicode: bool,
+                focused_block: FocusedBlock,
+                title_block: FocusedBlock,
+                title: &str,
+            ) -> String {
                 if !unicode && (focused_block == title_block) {
                     format!("[{}]", title.to_uppercase())
                 } else {
@@ -1144,46 +1175,79 @@ impl Adapter {
                 }
             }
 
-            let device_tab_title = format_tab_title(self.config.unicode, focused_block,
-                FocusedBlock::Device, "Device");
-            let station_tab_title = format_tab_title(self.config.unicode, focused_block,
-                FocusedBlock::Station, "Station");
-            let known_networks_tab_title = format_tab_title(self.config.unicode, focused_block,
+            let device_tab_title = format_tab_title(
+                self.config.unicode,
+                focused_block,
+                FocusedBlock::Device,
+                "Device",
+            );
+            let station_tab_title = format_tab_title(
+                self.config.unicode,
+                focused_block,
+                FocusedBlock::Station,
+                "Station",
+            );
+            let known_networks_tab_title = format_tab_title(
+                self.config.unicode,
+                focused_block,
                 FocusedBlock::KnownNetworks,
-                if frame.size().width >= 56 { "Known networks" } else { "Known nets" });
-            let new_networks_tab_title = format_tab_title(self.config.unicode, focused_block,
+                if frame.size().width >= 56 {
+                    "Known networks"
+                } else {
+                    "Known nets"
+                },
+            );
+            let new_networks_tab_title = format_tab_title(
+                self.config.unicode,
+                focused_block,
                 FocusedBlock::NewNetworks,
-                if frame.size().width >= 56 { "New networks" } else { "New nets" });
+                if frame.size().width >= 56 {
+                    "New networks"
+                } else {
+                    "New nets"
+                },
+            );
 
             let tabs = Tabs::new(vec![
-                device_tab_title, station_tab_title, known_networks_tab_title,
-                    new_networks_tab_title]
-            )
+                device_tab_title,
+                station_tab_title,
+                known_networks_tab_title,
+                new_networks_tab_title,
+            ])
             .style(Style::default().fg(Color::White));
 
             if focused_block == FocusedBlock::Device {
                 frame.render_widget(tabs.select(0), tab_bar_block);
-                self.render_device_table(frame, content_block,
-                    false /* don't render title */,
-                    true /* device block focused */ );
-
+                self.render_device_table(
+                    frame,
+                    content_block,
+                    false, /* don't render title */
+                    true,  /* device block focused */
+                );
             } else if focused_block == FocusedBlock::Station {
                 frame.render_widget(tabs.select(1), tab_bar_block);
-                self.render_station_table(frame, content_block,
-                    false /* don't render title */,
-                    true /* station block focused */ );
-
+                self.render_station_table(
+                    frame,
+                    content_block,
+                    false, /* don't render title */
+                    true,  /* station block focused */
+                );
             } else if focused_block == FocusedBlock::KnownNetworks {
                 frame.render_widget(tabs.select(2), tab_bar_block);
-                self.render_known_networks_table(frame, content_block,
-                    false /* don't render title */,
-                    true /* known networks block focused */ );
-
+                self.render_known_networks_table(
+                    frame,
+                    content_block,
+                    false, /* don't render title */
+                    true,  /* known networks block focused */
+                );
             } else if focused_block == FocusedBlock::NewNetworks {
                 frame.render_widget(tabs.select(3), tab_bar_block);
-                self.render_new_networks_table(frame, content_block,
-                    false /* don't render title */,
-                    true /* new networks block focused */ );
+                self.render_new_networks_table(
+                    frame,
+                    content_block,
+                    false, /* don't render title */
+                    true,  /* new networks block focused */
+                );
             }
 
             self.render_status_bar(frame, status_bar_block);

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -13,7 +13,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::{ColorMode, FocusedBlock},
+    app::{ColorMode, CharSet, FocusedBlock},
     device::Device,
 };
 
@@ -1049,8 +1049,7 @@ impl Adapter {
         color_mode: ColorMode,
         focused_block: FocusedBlock,
     ) {
-        let screen_height = frame.size().height;
-        if screen_height > 30 {
+        if frame.size().height > 30 {
 
             let (device_block, station_block, known_networks_block, new_networks_block) = {
                 let chunks = Layout::default()
@@ -1099,9 +1098,32 @@ impl Adapter {
                 (chunks[0], chunks[1])
             };
 
+            // Differentiate selected tab with ASCII
+            fn format_tab_title(unicode: bool, focused_block: FocusedBlock,
+                title_block: FocusedBlock, title: &str) -> String {
+                if !unicode && (focused_block == title_block) {
+                    format!("[{}]", title.to_uppercase())
+                } else {
+                    format!(" {} ", title)
+                }
+            }
+
+            let unicode = false;
+            let device_tab_title = format_tab_title(unicode, focused_block,
+                FocusedBlock::Device, "Device");
+            let station_tab_title = format_tab_title(unicode, focused_block,
+                FocusedBlock::Station, "Station");
+            let known_networks_tab_title = format_tab_title(unicode, focused_block,
+                FocusedBlock::KnownNetworks,
+                if frame.size().width >= 56 { "Known networks" } else { "Known nets" });
+            let new_networks_tab_title = format_tab_title(unicode, focused_block,
+                FocusedBlock::NewNetworks,
+                if frame.size().width >= 56 { "New networks" } else { "New nets" });
+
             let tabs = Tabs::new(vec![
-                "Device", "Station", "Known networks", "New networks"
-            ])
+                device_tab_title, station_tab_title, known_networks_tab_title,
+                    new_networks_tab_title]
+            )
             .style(Style::default().fg(Color::White));
 
             if focused_block == FocusedBlock::Device {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1153,6 +1153,13 @@ impl Adapter {
     }
 
     pub fn render_adapter(&self, palette: &Palette, frame: &mut Frame) {
+
+        let width = if frame.size().width > 80 {
+            (frame.size().width - 80) / 2
+        } else {
+            frame.size().width
+        };
+
         let popup_layout = Layout::default()
             .direction(ratatui::layout::Direction::Vertical)
             .constraints(
@@ -1169,9 +1176,9 @@ impl Adapter {
             .direction(Direction::Horizontal)
             .constraints(
                 [
-                    Constraint::Length((frame.size().width - 80) / 2),
+                    Constraint::Length(width),
                     Constraint::Min(80),
-                    Constraint::Length((frame.size().width - 80) / 2),
+                    Constraint::Length(width),
                 ]
                 .as_ref(),
             )

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -8,7 +8,7 @@ use ratatui::{
     style::{Color, Style, Stylize},
     text::Line,
     widgets::{Block, BorderType, Borders, Cell, Clear, List, Padding, Row, Table,
-        TableState, Tabs},
+        TableState, Tabs, Paragraph},
     Frame,
 };
 
@@ -1061,6 +1061,24 @@ impl Adapter {
         );
     }
 
+    pub fn render_status_bar(&self, frame: &mut Frame, status_bar_block: Rect) {
+        let status_bar_content = Paragraph::new(format!(
+            "Q: quit Arrows/HJKL: move Space: connect ?: help"
+        ))
+        .style(Style::default()
+            .fg(match self.config.color_mode {
+                ColorMode::Light => Color::White,
+                _ => Color::Black
+            })
+            .bg(match self.config.color_mode {
+                ColorMode::Light => Color::Black,
+                _ => Color::White
+            })
+        );
+
+        frame.render_widget(status_bar_content, status_bar_block);
+    }
+
     pub fn render_station_mode(
         &self,
         frame: &mut Frame,
@@ -1104,15 +1122,16 @@ impl Adapter {
 
         // Render compact tabs view
         } else {
-            let (tab_bar_block, content_block) = {
+            let (tab_bar_block, content_block, status_bar_block) = {
                 let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
                     Constraint::Length(1),
                     Constraint::Min(0),
+                    Constraint::Length(1),
                 ].as_ref())
                 .split(frame.size());
-                (chunks[0], chunks[1])
+                (chunks[0], chunks[1], chunks[2])
             };
 
             // Differentiate selected tab with ASCII
@@ -1166,6 +1185,8 @@ impl Adapter {
                     false /* don't render title */,
                     true /* new networks block focused */ );
             }
+
+            self.render_status_bar(frame, status_bar_block);
         }
     }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -100,7 +100,7 @@ impl Adapter {
             }
         }]);
 
-        let narrow_mode = frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -219,7 +219,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode = frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -366,7 +366,7 @@ impl Adapter {
             ap_is_scanning,
         ]);
 
-        let narrow_mode = frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_cols;
 
         let widths = [
             Constraint::Length(10),
@@ -525,7 +525,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode = frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -672,7 +672,7 @@ impl Adapter {
 
         let row = Row::new(row);
 
-        let narrow_mode = frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_cols;
 
         let widths = [
             Constraint::Length(12),
@@ -821,7 +821,7 @@ impl Adapter {
             })
             .collect();
 
-        let narrow_mode = frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_cols;
 
         let widths = [
             Constraint::Length(1),
@@ -992,7 +992,7 @@ impl Adapter {
             })
             .collect();
 
-        let narrow_mode = frame.size().width < self.config.narrow_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_cols;
 
         let widths = [
             Constraint::Length(15),
@@ -1097,7 +1097,7 @@ impl Adapter {
     }
 
     pub fn render_station_mode(&self, frame: &mut Frame, focused_block: FocusedBlock) {
-        if frame.size().height > 30 {
+        if frame.size().height > self.config.small_layout_rows {
             let (device_block, station_block, known_networks_block, new_networks_block) = {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1049,7 +1049,9 @@ impl Adapter {
         color_mode: ColorMode,
         focused_block: FocusedBlock,
     ) {
-        if false {
+        let screen_height = frame.size().height;
+        if screen_height > 30 {
+
             let (device_block, station_block, known_networks_block, new_networks_block) = {
                 let chunks = Layout::default()
                     .direction(Direction::Vertical)

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -102,7 +102,7 @@ impl Adapter {
             }
         }]);
 
-        let narrow_mode =  frame.size().width < 72;
+        let narrow_mode =  frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -225,7 +225,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode =  frame.size().width < 72;
+        let narrow_mode =  frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -372,7 +372,7 @@ impl Adapter {
             ap_is_scanning,
         ]);
 
-        let narrow_mode =  frame.size().width < 72;
+        let narrow_mode =  frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(10),
@@ -531,7 +531,7 @@ impl Adapter {
             self.device.address.clone(),
         ]);
 
-        let narrow_mode =  frame.size().width < 72;
+        let narrow_mode =  frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(8),
@@ -678,7 +678,7 @@ impl Adapter {
 
         let row = Row::new(row);
 
-        let narrow_mode =  frame.size().width < 72;
+        let narrow_mode =  frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(12),
@@ -828,7 +828,7 @@ impl Adapter {
         })
         .collect();
 
-        let narrow_mode =  frame.size().width < 72;
+        let narrow_mode =  frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(1),
@@ -974,7 +974,7 @@ impl Adapter {
         })
         .collect();
 
-        let narrow_mode =  frame.size().width < 72;
+        let narrow_mode =  frame.size().width < self.config.narrow_cols;
 
         let widths = [
             Constraint::Length(15),

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1108,7 +1108,7 @@ impl Adapter {
                 known_networks_tab_title,
                 new_networks_tab_title,
             ])
-            .style(palette.text);
+            .style(palette.text).highlight_style(palette.active_table_row);
 
             if focused_block == FocusedBlock::Device {
                 frame.render_widget(tabs.select(0), tab_bar_block);

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
-    style::{Color, Style, Stylize},
+    style::{Style, Stylize},
     text::Text,
     widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
     Frame,
@@ -19,7 +19,13 @@ use async_channel::{Receiver, Sender};
 use futures::FutureExt;
 use iwdrs::{agent::Agent, session::Session};
 
-use crate::{adapter::Adapter, config::Config, help::Help, notification::Notification};
+use crate::{
+    adapter::Adapter,
+    config::Config,
+    help::Help,
+    notification::Notification,
+    tui::Palette,
+};
 
 pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 
@@ -176,7 +182,7 @@ impl App {
         Ok(())
     }
 
-    pub fn render(&self, frame: &mut Frame) {
+    pub fn render(&self, palette: &Palette, frame: &mut Frame) {
         let popup_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints(
@@ -284,15 +290,15 @@ impl App {
 
         let message = Paragraph::new("Please select a mode:")
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::White))
+            .style(palette.text)
             .block(Block::new().padding(Padding::uniform(1)));
 
         let station_choice = Paragraph::new(station_text)
-            .style(Style::default().fg(Color::White))
+            .style(palette.text)
             .block(Block::new().padding(Padding::horizontal(10)));
 
         let ap_choice = Paragraph::new(ap_text)
-            .style(Style::default().fg(Color::White))
+            .style(palette.text)
             .block(Block::new().padding(Padding::horizontal(10)));
 
         let help = Paragraph::new(
@@ -300,7 +306,7 @@ impl App {
                 .style(Style::default().blue()),
         )
         .alignment(Alignment::Center)
-        .style(Style::default())
+        .style(palette.text)
         .block(Block::new().padding(Padding::horizontal(1)));
 
         frame.render_widget(Clear, area);
@@ -309,8 +315,8 @@ impl App {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
-                .style(Style::default().green())
-                .border_style(Style::default().fg(Color::Green)),
+                .style(palette.active_border)
+                .border_style(palette.active_border),
             area,
         );
         frame.render_widget(message, message_area);

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,7 +169,9 @@ impl App {
             }
         };
 
-        let adapter = Adapter::new(Arc::new(Config::default()), session.clone()).await.unwrap();
+        let adapter = Adapter::new(Arc::new(Config::default()), session.clone())
+            .await
+            .unwrap();
         adapter.device.set_mode(mode).await?;
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,6 +43,12 @@ pub enum ColorMode {
     Light,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CharSet {
+    Unicode,
+    Ascii
+}
+
 #[derive(Debug)]
 pub struct App {
     pub running: bool,

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,7 +98,7 @@ impl App {
         };
 
         // Start scanning if enabled
-        if config.station.auto_scan {
+        if (mode == "station") && config.station.auto_scan {
             let iwd_station = session.station().unwrap();
             match iwd_station.scan().await {
                 Ok(_) => (),

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,6 +183,13 @@ impl App {
     }
 
     pub fn render(&self, palette: &Palette, frame: &mut Frame) {
+
+        let width = if frame.size().width > 50 {
+            (frame.size().width - 50) / 2
+        } else {
+            frame.size().width
+        };
+
         let popup_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints(
@@ -199,9 +206,9 @@ impl App {
             .direction(Direction::Horizontal)
             .constraints(
                 [
-                    Constraint::Length((frame.size().width - 50) / 2),
+                    Constraint::Length(width),
                     Constraint::Min(50),
-                    Constraint::Length((frame.size().width - 50) / 2),
+                    Constraint::Length(width),
                 ]
                 .as_ref(),
             )

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,14 +1,15 @@
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
-    style::{Color, Style, Stylize},
     widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
     Frame,
 };
 
+use crate::tui::Palette;
+
 pub struct Auth;
 
 impl Auth {
-    pub fn render(&self, frame: &mut Frame, passkey: &str) {
+    pub fn render(&self, palette: &Palette, frame: &mut Frame, passkey: &str) {
         let popup_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints(
@@ -78,12 +79,12 @@ impl Auth {
 
         let text = Paragraph::new("Enter the password")
             .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::White))
+            .style(palette.text)
             .block(Block::new().padding(Padding::uniform(1)));
 
         let passkey = Paragraph::new(passkey)
-            .style(Style::default().fg(Color::White))
-            .block(Block::new().style(Style::default().bg(Color::DarkGray)));
+            .style(palette.input_text)
+            .block(Block::new().style(palette.input_box));
 
         frame.render_widget(Clear, area);
 
@@ -91,8 +92,8 @@ impl Auth {
             Block::new()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Thick)
-                .style(Style::default().green())
-                .border_style(Style::default().fg(Color::Green)),
+                .style(palette.active_border)
+                .border_style(palette.active_border),
             area,
         );
         frame.render_widget(text, text_area);

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -10,6 +10,13 @@ pub struct Auth;
 
 impl Auth {
     pub fn render(&self, palette: &Palette, frame: &mut Frame, passkey: &str) {
+
+        let width = if frame.size().width > 80 {
+            (frame.size().width - 80) / 2
+        } else {
+            frame.size().width
+        };
+
         let popup_layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints(
@@ -26,9 +33,9 @@ impl Auth {
             .direction(Direction::Horizontal)
             .constraints(
                 [
-                    Constraint::Length((frame.size().width - 80) / 2),
+                    Constraint::Length(width),
                     Constraint::Min(80),
-                    Constraint::Length((frame.size().width - 80) / 2),
+                    Constraint::Length(width),
                 ]
                 .as_ref(),
             )

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -82,7 +82,6 @@ impl Auth {
             .block(Block::new().padding(Padding::uniform(1)));
 
         let passkey = Paragraph::new(passkey)
-            .alignment(Alignment::Center)
             .style(Style::default().fg(Color::White))
             .block(Block::new().style(Style::default().bg(Color::DarkGray)));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,8 +38,11 @@ pub struct Config {
     #[serde(default = "default_color_mode")]
     pub color_mode: ColorMode,
 
-    #[serde(default = "default_narrow_cols")]
-    pub narrow_cols: u16,
+    #[serde(default = "default_small_layout_rows")]
+    pub small_layout_rows: u16,
+
+    #[serde(default = "default_small_layout_cols")]
+    pub small_layout_cols: u16,
 
     #[serde(default)]
     pub device: Device,
@@ -67,7 +70,11 @@ fn default_color_mode() -> ColorMode {
     ColorMode::Auto
 }
 
-fn default_narrow_cols() -> u16 {
+fn default_small_layout_rows() -> u16 {
+    30
+}
+
+fn default_small_layout_cols() -> u16 {
     80
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,9 @@ pub struct Config {
     #[serde(default = "default_color_mode")]
     pub color_mode: ColorMode,
 
+    #[serde(default = "default_monochrome")]
+    pub monochrome: bool,
+
     #[serde(default = "default_small_layout_height")]
     pub small_layout_height: u16,
 
@@ -68,6 +71,10 @@ fn default_unicode() -> bool {
 
 fn default_color_mode() -> ColorMode {
     ColorMode::Auto
+}
+
+fn default_monochrome() -> bool {
+    false
 }
 
 fn default_small_layout_height() -> u16 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,11 +38,11 @@ pub struct Config {
     #[serde(default = "default_color_mode")]
     pub color_mode: ColorMode,
 
-    #[serde(default = "default_small_layout_rows")]
-    pub small_layout_rows: u16,
+    #[serde(default = "default_small_layout_height")]
+    pub small_layout_height: u16,
 
-    #[serde(default = "default_small_layout_cols")]
-    pub small_layout_cols: u16,
+    #[serde(default = "default_small_layout_width")]
+    pub small_layout_width: u16,
 
     #[serde(default)]
     pub device: Device,
@@ -70,11 +70,11 @@ fn default_color_mode() -> ColorMode {
     ColorMode::Auto
 }
 
-fn default_small_layout_rows() -> u16 {
+fn default_small_layout_height() -> u16 {
     30
 }
 
-fn default_small_layout_cols() -> u16 {
+fn default_small_layout_width() -> u16 {
     80
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,9 @@ pub struct Config {
     #[serde(default = "default_color_mode")]
     pub color_mode: ColorMode,
 
+    #[serde(default = "default_narrow_cols")]
+    pub narrow_cols: u16,
+
     #[serde(default)]
     pub device: Device,
 
@@ -60,6 +63,10 @@ fn default_unicode() -> bool {
 
 fn default_color_mode() -> ColorMode {
     ColorMode::Auto
+}
+
+fn default_narrow_cols() -> u16 {
+    80
 }
 
 // Device

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,9 @@ pub struct Config {
     #[serde(default = "default_device_mode")]
     pub mode: String,
 
+    #[serde(default = "default_unicode")]
+    pub unicode: bool,
+
     #[serde(default)]
     pub device: Device,
 
@@ -27,6 +30,10 @@ fn default_switch_mode() -> char {
 
 fn default_device_mode() -> String {
     String::from("station")
+}
+
+fn default_unicode() -> bool {
+    true
 }
 
 // Device

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,9 @@ pub enum ColorMode {
 
 impl<'de> Deserialize<'de> for ColorMode {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: Deserializer<'de>, {
+    where
+        D: Deserializer<'de>,
+    {
         let s: String = Deserialize::deserialize(deserializer)?;
         match s.to_lowercase().as_str() {
             "auto" => Ok(ColorMode::Auto),

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,9 @@ pub struct Station {
     #[serde(default = "default_station_toggle_connect")]
     pub toggle_connect: char,
 
+    #[serde(default = "default_station_auto_scan")]
+    pub auto_scan: bool,
+
     #[serde(default)]
     pub known_network: KnownNetwork,
 }
@@ -69,6 +72,7 @@ impl Default for Station {
             start_scanning: 's',
             toggle_connect: ' ',
             known_network: KnownNetwork::default(),
+            auto_scan: true,
         }
     }
 }
@@ -99,6 +103,10 @@ impl Default for KnownNetwork {
 
 fn default_station_remove_known_network() -> char {
     'd'
+}
+
+fn default_station_auto_scan() -> bool {
+    true
 }
 
 // Access Point

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,26 @@
 use toml;
 
 use dirs;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ColorMode {
+    Auto,
+    Dark,
+    Light,
+}
+
+impl<'de> Deserialize<'de> for ColorMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: Deserializer<'de>, {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(ColorMode::Auto),
+            "light" => Ok(ColorMode::Light),
+            _ => Ok(ColorMode::Dark),
+        }
+    }
+}
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -13,6 +32,9 @@ pub struct Config {
 
     #[serde(default = "default_unicode")]
     pub unicode: bool,
+
+    #[serde(default = "default_color_mode")]
+    pub color_mode: ColorMode,
 
     #[serde(default)]
     pub device: Device,
@@ -34,6 +56,10 @@ fn default_device_mode() -> String {
 
 fn default_unicode() -> bool {
     true
+}
+
+fn default_color_mode() -> ColorMode {
+    ColorMode::Auto
 }
 
 // Device

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -159,7 +159,7 @@ pub async fn handle_key_events(
                     };
                 }
 
-                KeyCode::Tab | KeyCode::Char('l') | KeyCode::Right =>
+                KeyCode::Tab | KeyCode::Char('l') | KeyCode::Right => {
                     match app.adapter.device.mode.as_str() {
                         "station" => match app.focused_block {
                             FocusedBlock::Device => {
@@ -185,7 +185,8 @@ pub async fn handle_key_events(
                                     if ap.connected_devices.is_empty() {
                                         app.focused_block = FocusedBlock::Device;
                                     } else {
-                                        app.focused_block = FocusedBlock::AccessPointConnectedDevices;
+                                        app.focused_block =
+                                            FocusedBlock::AccessPointConnectedDevices;
                                     }
                                 }
                             }
@@ -207,9 +208,10 @@ pub async fn handle_key_events(
                             _ => {}
                         },
                         _ => {}
-                    },
+                    }
+                }
 
-                    KeyCode::BackTab | KeyCode::Char('h') | KeyCode::Left =>
+                KeyCode::BackTab | KeyCode::Char('h') | KeyCode::Left => {
                     match app.adapter.device.mode.as_str() {
                         "station" => match app.focused_block {
                             FocusedBlock::Device => {
@@ -232,7 +234,8 @@ pub async fn handle_key_events(
                                     if ap.connected_devices.is_empty() {
                                         app.focused_block = FocusedBlock::AccessPoint;
                                     } else {
-                                        app.focused_block = FocusedBlock::AccessPointConnectedDevices;
+                                        app.focused_block =
+                                            FocusedBlock::AccessPointConnectedDevices;
                                     }
                                 }
                             }
@@ -257,7 +260,8 @@ pub async fn handle_key_events(
                             _ => {}
                         },
                         _ => {}
-                    },
+                    }
+                }
 
                 _ => {
                     match app.focused_block {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -131,6 +131,13 @@ pub async fn handle_key_events(
                         || app.focused_block == FocusedBlock::AdapterInfos
                     {
                         app.focused_block = FocusedBlock::Device;
+                    } else if app.focused_block == FocusedBlock::Device
+                        || app.focused_block == FocusedBlock::Station
+                        || app.focused_block == FocusedBlock::AccessPoint
+                        || app.focused_block == FocusedBlock::KnownNetworks
+                        || app.focused_block == FocusedBlock::NewNetworks
+                    {
+                        app.quit();
                     }
                 }
 
@@ -159,103 +166,105 @@ pub async fn handle_key_events(
                     };
                 }
 
-                KeyCode::Tab => match app.adapter.device.mode.as_str() {
-                    "station" => match app.focused_block {
-                        FocusedBlock::Device => {
-                            app.focused_block = FocusedBlock::Station;
-                        }
-                        FocusedBlock::Station => {
-                            app.focused_block = FocusedBlock::KnownNetworks;
-                        }
-                        FocusedBlock::KnownNetworks => {
-                            app.focused_block = FocusedBlock::NewNetworks;
-                        }
-                        FocusedBlock::NewNetworks => {
-                            app.focused_block = FocusedBlock::Device;
-                        }
-                        _ => {}
-                    },
-                    "ap" => match app.focused_block {
-                        FocusedBlock::Device => {
-                            app.focused_block = FocusedBlock::AccessPoint;
-                        }
-                        FocusedBlock::AccessPoint => {
-                            if let Some(ap) = app.adapter.device.access_point.as_ref() {
-                                if ap.connected_devices.is_empty() {
-                                    app.focused_block = FocusedBlock::Device;
-                                } else {
-                                    app.focused_block = FocusedBlock::AccessPointConnectedDevices;
+                KeyCode::Tab | KeyCode::Char('l') | KeyCode::Right =>
+                    match app.adapter.device.mode.as_str() {
+                        "station" => match app.focused_block {
+                            FocusedBlock::Device => {
+                                app.focused_block = FocusedBlock::Station;
+                            }
+                            FocusedBlock::Station => {
+                                app.focused_block = FocusedBlock::KnownNetworks;
+                            }
+                            FocusedBlock::KnownNetworks => {
+                                app.focused_block = FocusedBlock::NewNetworks;
+                            }
+                            FocusedBlock::NewNetworks => {
+                                app.focused_block = FocusedBlock::Device;
+                            }
+                            _ => {}
+                        },
+                        "ap" => match app.focused_block {
+                            FocusedBlock::Device => {
+                                app.focused_block = FocusedBlock::AccessPoint;
+                            }
+                            FocusedBlock::AccessPoint => {
+                                if let Some(ap) = app.adapter.device.access_point.as_ref() {
+                                    if ap.connected_devices.is_empty() {
+                                        app.focused_block = FocusedBlock::Device;
+                                    } else {
+                                        app.focused_block = FocusedBlock::AccessPointConnectedDevices;
+                                    }
                                 }
                             }
-                        }
-                        FocusedBlock::AccessPointConnectedDevices => {
-                            app.focused_block = FocusedBlock::Device;
-                        }
-                        FocusedBlock::AccessPointInput => {
-                            if let Some(ap) = &mut app.adapter.device.access_point {
-                                match ap.focused_section {
-                                    APFocusedSection::SSID => {
-                                        ap.focused_section = APFocusedSection::PSK
-                                    }
-                                    APFocusedSection::PSK => {
-                                        ap.focused_section = APFocusedSection::SSID
-                                    }
-                                };
+                            FocusedBlock::AccessPointConnectedDevices => {
+                                app.focused_block = FocusedBlock::Device;
                             }
-                        }
+                            FocusedBlock::AccessPointInput => {
+                                if let Some(ap) = &mut app.adapter.device.access_point {
+                                    match ap.focused_section {
+                                        APFocusedSection::SSID => {
+                                            ap.focused_section = APFocusedSection::PSK
+                                        }
+                                        APFocusedSection::PSK => {
+                                            ap.focused_section = APFocusedSection::SSID
+                                        }
+                                    };
+                                }
+                            }
+                            _ => {}
+                        },
                         _ => {}
                     },
-                    _ => {}
-                },
 
-                KeyCode::BackTab => match app.adapter.device.mode.as_str() {
-                    "station" => match app.focused_block {
-                        FocusedBlock::Device => {
-                            app.focused_block = FocusedBlock::NewNetworks;
-                        }
-                        FocusedBlock::Station => {
-                            app.focused_block = FocusedBlock::Device;
-                        }
-                        FocusedBlock::KnownNetworks => {
-                            app.focused_block = FocusedBlock::Station;
-                        }
-                        FocusedBlock::NewNetworks => {
-                            app.focused_block = FocusedBlock::KnownNetworks;
-                        }
-                        _ => {}
-                    },
-                    "ap" => match app.focused_block {
-                        FocusedBlock::Device => {
-                            if let Some(ap) = app.adapter.device.access_point.as_ref() {
-                                if ap.connected_devices.is_empty() {
-                                    app.focused_block = FocusedBlock::AccessPoint;
-                                } else {
-                                    app.focused_block = FocusedBlock::AccessPointConnectedDevices;
+                    KeyCode::BackTab | KeyCode::Char('h') | KeyCode::Left =>
+                    match app.adapter.device.mode.as_str() {
+                        "station" => match app.focused_block {
+                            FocusedBlock::Device => {
+                                app.focused_block = FocusedBlock::NewNetworks;
+                            }
+                            FocusedBlock::Station => {
+                                app.focused_block = FocusedBlock::Device;
+                            }
+                            FocusedBlock::KnownNetworks => {
+                                app.focused_block = FocusedBlock::Station;
+                            }
+                            FocusedBlock::NewNetworks => {
+                                app.focused_block = FocusedBlock::KnownNetworks;
+                            }
+                            _ => {}
+                        },
+                        "ap" => match app.focused_block {
+                            FocusedBlock::Device => {
+                                if let Some(ap) = app.adapter.device.access_point.as_ref() {
+                                    if ap.connected_devices.is_empty() {
+                                        app.focused_block = FocusedBlock::AccessPoint;
+                                    } else {
+                                        app.focused_block = FocusedBlock::AccessPointConnectedDevices;
+                                    }
                                 }
                             }
-                        }
-                        FocusedBlock::AccessPoint => {
-                            app.focused_block = FocusedBlock::Device;
-                        }
-                        FocusedBlock::AccessPointConnectedDevices => {
-                            app.focused_block = FocusedBlock::AccessPoint;
-                        }
-                        FocusedBlock::AccessPointInput => {
-                            if let Some(ap) = &mut app.adapter.device.access_point {
-                                match ap.focused_section {
-                                    APFocusedSection::SSID => {
-                                        ap.focused_section = APFocusedSection::PSK
-                                    }
-                                    APFocusedSection::PSK => {
-                                        ap.focused_section = APFocusedSection::SSID
-                                    }
-                                };
+                            FocusedBlock::AccessPoint => {
+                                app.focused_block = FocusedBlock::Device;
                             }
-                        }
+                            FocusedBlock::AccessPointConnectedDevices => {
+                                app.focused_block = FocusedBlock::AccessPoint;
+                            }
+                            FocusedBlock::AccessPointInput => {
+                                if let Some(ap) = &mut app.adapter.device.access_point {
+                                    match ap.focused_section {
+                                        APFocusedSection::SSID => {
+                                            ap.focused_section = APFocusedSection::PSK
+                                        }
+                                        APFocusedSection::PSK => {
+                                            ap.focused_section = APFocusedSection::SSID
+                                        }
+                                    };
+                                }
+                            }
+                            _ => {}
+                        },
                         _ => {}
                     },
-                    _ => {}
-                },
 
                 _ => {
                     match app.focused_block {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -131,13 +131,6 @@ pub async fn handle_key_events(
                         || app.focused_block == FocusedBlock::AdapterInfos
                     {
                         app.focused_block = FocusedBlock::Device;
-                    } else if app.focused_block == FocusedBlock::Device
-                        || app.focused_block == FocusedBlock::Station
-                        || app.focused_block == FocusedBlock::AccessPoint
-                        || app.focused_block == FocusedBlock::KnownNetworks
-                        || app.focused_block == FocusedBlock::NewNetworks
-                    {
-                        app.quit();
                     }
                 }
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -10,9 +10,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::{
-    config::{Config, ColorMode}
-};
+use crate::config::{ColorMode, Config};
 
 #[derive(Debug, Clone)]
 pub struct Help {

--- a/src/help.rs
+++ b/src/help.rs
@@ -145,47 +145,52 @@ impl Help {
             _ => Style::default().fg(Color::White),
         };
 
-        let narrow_mode = frame.size().width < self.config.small_layout_cols;
+        let narrow_mode = frame.size().width < self.config.small_layout_width;
         let row_title_width = 20;
         let table_block_padding = if narrow_mode { 0 } else { 2 };
 
         let widths = [Constraint::Length(row_title_width), Constraint::Fill(1)];
-        let max_row_detail_length = (
-            block.width - row_title_width
-            - 3 * table_block_padding // Cell padding
-            - 3
+
+        // Calculate maximum length for the help text detail
+        let max_row_detail_length = (block.width - row_title_width
+            // Cell padding
+            - 3 * table_block_padding
             // Borders
-        ) as usize;
+            - 3) as usize;
 
         let rows: Vec<Row> = self
             .keys
             .iter()
             .flat_map(|key| {
-                // Split row details into new rows to emulate line wrap
+                // Split help text into new lines to emulate line wrap
                 let mut lines = Vec::new();
+
+                // Start with whole text
                 let mut remainder = key.1;
 
-                // Keep splitting
+                // Keep splitting at maximum row length
                 while remainder.len() > max_row_detail_length {
                     let (line, rest) = remainder.split_at(max_row_detail_length);
+
+                    // Add new split line
                     lines.push(line.to_owned());
                     remainder = rest;
                 }
 
-                // Add the last split
+                // Add the rest of the line
                 lines.push(remainder.to_owned());
 
-                // Create a row for each line
+                // Create a table row for each line
                 let mut rows = Vec::new();
 
-                // First row: key.0 and first line of key.1
+                // First row: key.0 and first line of help text
                 if !lines.is_empty() {
                     rows.push(
                         Row::new(vec![key.0.to_owned(), Cell::from(lines[0].clone())]).style(style),
                     );
                 }
 
-                // Rest of rows: only remaining lines of key.1
+                // Rest of rows: only the split lines of help text
                 for line in lines.iter().skip(1) {
                     rows.push(Row::new(vec!["".to_owned(), line.clone()]).style(style));
                 }

--- a/src/help.rs
+++ b/src/help.rs
@@ -10,10 +10,13 @@ use ratatui::{
     Frame,
 };
 
-use crate::{app::ColorMode, config::Config};
+use crate::{
+    config::{Config, ColorMode}
+};
 
 #[derive(Debug, Clone)]
 pub struct Help {
+    config: Arc<Config>,
     block_height: usize,
     state: TableState,
     keys: Vec<(Cell<'static>, &'static str)>,
@@ -25,6 +28,7 @@ impl Help {
         state.select(Some(0));
 
         Self {
+            config: config.clone(),
             block_height: 0,
             state,
             keys: vec![
@@ -132,7 +136,7 @@ impl Help {
         self.state.select(Some(i));
     }
 
-    pub fn render(&mut self, frame: &mut Frame, color_mode: ColorMode) {
+    pub fn render(&mut self, frame: &mut Frame) {
         let block = help_rect(frame.size());
 
         self.block_height = block.height as usize;
@@ -141,9 +145,9 @@ impl Help {
             .keys
             .iter()
             .map(|key| {
-                Row::new(vec![key.0.to_owned(), key.1.into()]).style(match color_mode {
-                    ColorMode::Dark => Style::default().fg(Color::White),
+                Row::new(vec![key.0.to_owned(), key.1.into()]).style(match self.config.color_mode {
                     ColorMode::Light => Style::default().fg(Color::Black),
+                    _ => Style::default().fg(Color::White),
                 })
             })
             .collect();

--- a/src/help.rs
+++ b/src/help.rs
@@ -38,7 +38,7 @@ impl Help {
                 ),
                 (Cell::from("Esc").bold(), "Dismiss different pop-ups"),
                 (
-                    Cell::from("Tab or Shift+Tab").bold(),
+                    Cell::from("Tab, Shift+Tab, Left, Right, h, l").bold(),
                     "Switch between different sections",
                 ),
                 (Cell::from("j or Down").bold(), "Scroll down"),

--- a/src/help.rs
+++ b/src/help.rs
@@ -227,6 +227,9 @@ impl Help {
 }
 
 pub fn help_rect(r: Rect) -> Rect {
+
+    let width = if r.width > 80 { (r.width - 80) / 2 } else { r.width };
+
     let popup_layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints(
@@ -243,9 +246,9 @@ pub fn help_rect(r: Rect) -> Rect {
         .direction(Direction::Horizontal)
         .constraints(
             [
-                Constraint::Length((r.width - 80) / 2),
+                Constraint::Length(width),
                 Constraint::Min(80),
-                Constraint::Length((r.width - 80) / 2),
+                Constraint::Length(width),
             ]
             .as_ref(),
         )

--- a/src/help.rs
+++ b/src/help.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Margin, Rect},
-    style::{Color, Style, Stylize},
+    style::Stylize,
     widgets::{
         Block, BorderType, Borders, Cell, Clear, Padding, Row, Scrollbar, ScrollbarOrientation,
         ScrollbarState, Table, TableState,
@@ -10,28 +10,29 @@ use ratatui::{
     Frame,
 };
 
-use crate::config::{ColorMode, Config};
+use crate::{
+    tui::Palette,
+    config::Config,
+};
 
 #[derive(Debug, Clone)]
 pub struct Help {
-    config: Arc<Config>,
     block_height: usize,
     state: TableState,
     keys: Vec<(Cell<'static>, &'static str)>,
 }
 
 impl Help {
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Arc<Config>, palette: &Palette) -> Self {
         let mut state = TableState::new().with_offset(0);
         state.select(Some(0));
 
         Self {
-            config: config.clone(),
             block_height: 0,
             state,
             keys: vec![
                 (
-                    Cell::from("## Global").style(Style::new().bold().fg(Color::Yellow)),
+                    Cell::from("## Global").style(palette.active_table_header.bold()),
                     "",
                 ),
                 (Cell::from("Esc").bold(), "Dismiss different pop-ups"),
@@ -50,7 +51,7 @@ impl Help {
                 (Cell::from("q or ctrl+c").bold(), "Quit"),
                 (Cell::from(""), ""),
                 (
-                    Cell::from("## Device").style(Style::new().bold().fg(Color::Yellow)),
+                    Cell::from("## Device").style(palette.active_table_header.bold()),
                     "",
                 ),
                 (
@@ -63,7 +64,7 @@ impl Help {
                 ),
                 (Cell::from(""), ""),
                 (
-                    Cell::from("## Station").style(Style::new().bold().fg(Color::Yellow)),
+                    Cell::from("## Station").style(palette.active_table_header.bold()),
                     "",
                 ),
                 (
@@ -82,7 +83,7 @@ impl Help {
                     "Connect/Disconnect the network",
                 ),
                 (
-                    Cell::from("### Known Networks").style(Style::new().bold().fg(Color::Yellow)),
+                    Cell::from("### Known Networks").style(palette.active_table_header.bold()),
                     "",
                 ),
                 (
@@ -91,7 +92,7 @@ impl Help {
                 ),
                 (Cell::from(""), ""),
                 (
-                    Cell::from("## Access Point").style(Style::new().bold().fg(Color::Yellow)),
+                    Cell::from("## Access Point").style(palette.active_table_header.bold()),
                     "",
                 ),
                 (
@@ -135,19 +136,13 @@ impl Help {
         self.state.select(Some(i));
     }
 
-    pub fn render(&mut self, frame: &mut Frame) {
+    pub fn render(&mut self, palette: &Palette, frame: &mut Frame) {
         let block = help_rect(frame.size());
 
         self.block_height = block.height as usize;
 
-        let style = match self.config.color_mode {
-            ColorMode::Light => Style::default().fg(Color::Black),
-            _ => Style::default().fg(Color::White),
-        };
-
-        let narrow_mode = frame.size().width < self.config.small_layout_width;
         let row_title_width = 20;
-        let table_block_padding = if narrow_mode { 0 } else { 2 };
+        let table_block_padding = 1;
 
         let widths = [Constraint::Length(row_title_width), Constraint::Fill(1)];
 
@@ -186,13 +181,13 @@ impl Help {
                 // First row: key.0 and first line of help text
                 if !lines.is_empty() {
                     rows.push(
-                        Row::new(vec![key.0.to_owned(), Cell::from(lines[0].clone())]).style(style),
+                        Row::new(vec![key.0.to_owned(), Cell::from(lines[0].clone())]).style(palette.text),
                     );
                 }
 
                 // Rest of rows: only the split lines of help text
                 for line in lines.iter().skip(1) {
-                    rows.push(Row::new(vec!["".to_owned(), line.clone()]).style(style));
+                    rows.push(Row::new(vec!["".to_owned(), line.clone()]).style(palette.text));
                 }
 
                 rows
@@ -204,12 +199,12 @@ impl Help {
             Block::default()
                 .padding(Padding::uniform(table_block_padding))
                 .title(" Help ")
-                .title_style(Style::default().bold().fg(Color::Green))
+                .title_style(palette.active_border)
                 .title_alignment(Alignment::Center)
                 .borders(Borders::ALL)
-                .style(Style::default())
+                .style(palette.text)
                 .border_type(BorderType::Thick)
-                .border_style(Style::default().fg(Color::Green)),
+                .border_style(palette.active_border),
         );
 
         frame.render_widget(Clear, block);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use impala::event::{Event, EventHandler};
 use impala::handler::handle_key_events;
 use impala::help::Help;
 use impala::tracing::Tracing;
-use impala::tui::Tui;
+use impala::tui::{Tui, generate_palette};
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use std::io;
@@ -32,9 +32,12 @@ async fn main() -> AppResult<()> {
         config
     });
 
+    let palette = generate_palette(config.color_mode == ColorMode::Light,
+        config.monochrome);
+
     let mode = args.get_one::<String>("mode").cloned();
 
-    let help = Help::new(config.clone());
+    let help = Help::new(config.clone(), &palette);
 
     let mode = mode.unwrap_or_else(|| config.mode.clone());
 
@@ -44,7 +47,7 @@ async fn main() -> AppResult<()> {
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
     let events = EventHandler::new(3000);
-    let mut tui = Tui::new(terminal, events);
+    let mut tui = Tui::new(terminal, events, palette);
     tui.init()?;
 
     while app.running {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use impala::app::{App, AppResult};
 use impala::cli;
-use impala::config::Config;
+use impala::config::{Config, ColorMode};
 use impala::event::{Event, EventHandler};
 use impala::handler::handle_key_events;
 use impala::help::Help;
@@ -17,7 +17,21 @@ async fn main() -> AppResult<()> {
 
     let args = cli::cli().get_matches();
 
-    let config = Arc::new(Config::new());
+    let config = Arc::new({
+        let mut config = Config::new();
+
+        // Automatically detect color mode
+        if config.color_mode == ColorMode::Auto {
+
+            config.color_mode = match terminal_light::luma() {
+                Ok(luma) if luma > 0.6 => ColorMode::Light,
+                Ok(_) => ColorMode::Dark,
+                Err(_) => ColorMode::Dark,
+            };
+        }
+
+        config
+    });
 
     let mode = args.get_one::<String>("mode").cloned();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use impala::app::{App, AppResult};
 use impala::cli;
-use impala::config::{Config, ColorMode};
+use impala::config::{ColorMode, Config};
 use impala::event::{Event, EventHandler};
 use impala::handler::handle_key_events;
 use impala::help::Help;
@@ -22,7 +22,6 @@ async fn main() -> AppResult<()> {
 
         // Automatically detect color mode
         if config.color_mode == ColorMode::Auto {
-
             config.color_mode = match terminal_light::luma() {
                 Ok(luma) if luma > 0.6 => ColorMode::Light,
                 Ok(_) => ColorMode::Dark,

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> AppResult<()> {
 
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
-    let events = EventHandler::new(50000);
+    let events = EventHandler::new(5000);
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
 
@@ -67,6 +67,8 @@ async fn main() -> AppResult<()> {
             Event::Reset(mode) => {
                 App::reset(mode.clone()).await?;
                 app = App::new(help.clone(), config.clone(), mode).await?;
+                // Otherwise password dialog is not drawn until key pressed
+                tui.draw(&mut app)?;
             }
             _ => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> AppResult<()> {
 
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
-    let events = EventHandler::new(500);
+    let events = EventHandler::new(50000);
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> AppResult<()> {
     let mode = mode.unwrap_or_else(|| config.mode.clone());
 
     App::reset(mode.clone()).await?;
-    let mut app = App::new(help.clone(), mode).await?;
+    let mut app = App::new(help.clone(), config.clone(), mode).await?;
 
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
@@ -52,7 +52,7 @@ async fn main() -> AppResult<()> {
             }
             Event::Reset(mode) => {
                 App::reset(mode.clone()).await?;
-                app = App::new(help.clone(), mode).await?;
+                app = App::new(help.clone(), config.clone(), mode).await?;
             }
             _ => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> AppResult<()> {
 
     let backend = CrosstermBackend::new(io::stderr());
     let terminal = Terminal::new(backend)?;
-    let events = EventHandler::new(5000);
+    let events = EventHandler::new(3000);
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
 
@@ -67,8 +67,6 @@ async fn main() -> AppResult<()> {
             Event::Reset(mode) => {
                 App::reset(mode.clone()).await?;
                 app = App::new(help.clone(), config.clone(), mode).await?;
-                // Otherwise password dialog is not drawn until key pressed
-                tui.draw(&mut app)?;
             }
             _ => {}
         }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Text},
     widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap},
     Frame,
@@ -8,6 +8,8 @@ use ratatui::{
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{app::AppResult, event::Event};
+
+use crate::tui::Palette;
 
 #[derive(Debug, Clone)]
 pub struct Notification {
@@ -24,15 +26,15 @@ pub enum NotificationLevel {
 }
 
 impl Notification {
-    pub fn render(&self, index: usize, frame: &mut Frame) {
-        let (color, title) = match self.level {
-            NotificationLevel::Info => (Color::Green, "Info"),
-            NotificationLevel::Warning => (Color::Yellow, "Warning"),
-            NotificationLevel::Error => (Color::Red, "Error"),
+    pub fn render(&self, index: usize, palette: &Palette, frame: &mut Frame) {
+        let (style, title) = match self.level {
+            NotificationLevel::Info => (palette.notification_info, "Info"),
+            NotificationLevel::Warning => (palette.notification_warning, "Warning"),
+            NotificationLevel::Error => (palette.notification_error, "Error"),
         };
 
         let mut text = Text::from(vec![
-            Line::from(title).style(Style::new().fg(color).add_modifier(Modifier::BOLD))
+            Line::from(title).style(style.add_modifier(Modifier::BOLD))
         ]);
 
         text.extend(Text::from(self.message.as_str()));
@@ -48,7 +50,7 @@ impl Notification {
                     .borders(Borders::ALL)
                     .style(Style::default())
                     .border_type(BorderType::Thick)
-                    .border_style(Style::default().fg(color)),
+                    .border_style(style),
             );
 
         let area = notification_rect(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,7 @@
 use crate::app::{App, AppResult};
 use crate::event::EventHandler;
 use crate::ui;
+use ratatui::style::{Color, Style};
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::backend::Backend;
@@ -9,14 +10,137 @@ use std::io;
 use std::panic;
 
 #[derive(Debug)]
+pub struct Palette {
+    pub text: Style,
+
+    pub input_text: Style,
+    pub input_box: Style,
+
+    pub status_bar: Style,
+
+    pub active_border: Style,
+    pub inactive_border: Style,
+
+    pub active_table_header: Style,
+    pub inactive_table_header: Style,
+    pub active_table_row: Style,
+
+    pub notification_info: Style,
+    pub notification_warning: Style,
+    pub notification_error: Style,
+}
+
+#[derive(Debug)]
 pub struct Tui<B: Backend> {
     terminal: Terminal<B>,
     pub events: EventHandler,
+    pub palette: Palette,
+}
+
+// Build palette from color configuration
+pub fn generate_palette(light_mode:  bool, monochrome: bool) -> Palette {
+
+    // Light color scheme
+    if light_mode {
+
+        // Monochrome black-on-white color scheme
+        if monochrome {
+            Palette {
+                text: Style::default().fg(Color::Black),
+
+                input_text: Style::default().fg(Color::White),
+                input_box: Style::default().bg(Color::Black),
+
+                status_bar: Style::default().fg(Color::White).bg(Color::Black),
+            
+                active_border: Style::default().fg(Color::Black),
+                inactive_border: Style::default().fg(Color::Black),
+
+                active_table_header: Style::default().fg(Color::Black),
+                inactive_table_header: Style::default().fg(Color::Black),
+                active_table_row: Style::default().fg(Color::White).bg(Color::Black),
+
+                notification_info: Style::default().fg(Color::Black),
+                notification_warning: Style::default().fg(Color::Black),
+                notification_error: Style::default().fg(Color::Black),
+            }
+
+        // Colorful light scheme
+        } else {
+            Palette {
+                text: Style::default().fg(Color::Black),
+
+                input_text: Style::default().fg(Color::Black),
+                input_box: Style::default().bg(Color::DarkGray),
+
+                status_bar: Style::default().fg(Color::White).bg(Color::Black),
+            
+                active_border: Style::default().fg(Color::Green),
+                inactive_border: Style::default().fg(Color::Black),
+
+                active_table_header: Style::default().fg(Color::Yellow),
+                inactive_table_header: Style::default().fg(Color::Black),
+                active_table_row: Style::default().fg(Color::White).bg(Color::DarkGray),
+
+                notification_info: Style::default().fg(Color::Green),
+                notification_warning: Style::default().fg(Color::Yellow),
+                notification_error: Style::default().fg(Color::Red),
+            }
+        }
+
+    // Dark color scheme
+    } else {
+
+        // Monochrome white-on-black color scheme
+        if monochrome {
+            Palette {
+                text: Style::default().fg(Color::White),
+
+                input_text: Style::default().fg(Color::Black),
+                input_box: Style::default().bg(Color::White),
+
+                status_bar: Style::default().fg(Color::Black).bg(Color::White),
+            
+                active_border: Style::default().fg(Color::White),
+                inactive_border: Style::default().fg(Color::White),
+
+                active_table_header: Style::default().fg(Color::White),
+                inactive_table_header: Style::default().fg(Color::White),
+                active_table_row: Style::default().fg(Color::Black).bg(Color::White),
+
+                notification_info: Style::default().fg(Color::White),
+                notification_warning: Style::default().fg(Color::White),
+                notification_error: Style::default().fg(Color::White),
+            }
+
+        // Colorful dark scheme
+        } else {
+            Palette {
+                text: Style::default().fg(Color::White),
+
+                input_text: Style::default().fg(Color::White),
+                input_box: Style::default().bg(Color::DarkGray),
+
+                status_bar: Style::default().fg(Color::Black).bg(Color::White),
+            
+                active_border: Style::default().fg(Color::Green),
+                inactive_border: Style::default().fg(Color::White),
+
+                active_table_header: Style::default().fg(Color::Yellow),
+                inactive_table_header: Style::default().fg(Color::White),
+                active_table_row: Style::default().fg(Color::White).bg(Color::DarkGray),
+
+                notification_info: Style::default().fg(Color::Green),
+                notification_warning: Style::default().fg(Color::Yellow),
+                notification_error: Style::default().fg(Color::Red),
+            }
+        }
+    }
 }
 
 impl<B: Backend> Tui<B> {
-    pub fn new(terminal: Terminal<B>, events: EventHandler) -> Self {
-        Self { terminal, events }
+    pub fn new(terminal: Terminal<B>, events: EventHandler, palette: Palette) -> Self {
+        Self { terminal, events, palette }
     }
 
     pub fn init(&mut self) -> AppResult<()> {
@@ -36,7 +160,7 @@ impl<B: Backend> Tui<B> {
     }
 
     pub fn draw(&mut self, app: &mut App) -> AppResult<()> {
-        self.terminal.draw(|frame| ui::render(app, frame))?;
+        self.terminal.draw(|frame| ui::render(app, &self.palette, frame))?;
         Ok(())
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,7 +41,8 @@ impl<B: Backend> Tui<B> {
 
     fn reset() -> AppResult<()> {
         terminal::disable_raw_mode()?;
-        crossterm::execute!(io::stderr(), LeaveAlternateScreen, DisableMouseCapture)?;
+        crossterm::execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+        crossterm::execute!(io::stderr(), LeaveAlternateScreen)?;
         Ok(())
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,6 +22,7 @@ impl<B: Backend> Tui<B> {
     pub fn init(&mut self) -> AppResult<()> {
         terminal::enable_raw_mode()?;
         crossterm::execute!(io::stderr(), EnterAlternateScreen, EnableMouseCapture)?;
+        crossterm::execute!(io::stdout(), EnterAlternateScreen)?;
 
         let panic_hook = panic::take_hook();
         panic::set_hook(Box::new(move |panic| {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,40 +6,42 @@ use crate::app::{App, FocusedBlock};
 
 use crate::auth::Auth;
 
-pub fn render(app: &mut App, frame: &mut Frame) {
+use crate::tui::Palette;
+
+pub fn render(app: &mut App, palette: &Palette, frame: &mut Frame) {
     // Select mode
     if app.reset_mode {
-        app.render(frame);
+        app.render(palette, frame);
     } else {
         // App
-        app.adapter.render(frame, app.focused_block);
+        app.adapter.render(palette, frame, app.focused_block);
 
         if app.focused_block == FocusedBlock::AdapterInfos {
-            app.adapter.render_adapter(frame);
+            app.adapter.render_adapter(palette, frame);
         }
 
         // Auth Popup
         if app.authentication_required.load(Ordering::Relaxed) {
             app.focused_block = FocusedBlock::AuthKey;
-            Auth.render(frame, app.passkey_input.value());
+            Auth.render(palette, frame, app.passkey_input.value());
         }
 
         // Access Point Popup
         if let Some(ap) = &app.adapter.device.access_point {
             if ap.ap_start.load(Ordering::Relaxed) {
                 app.focused_block = FocusedBlock::AccessPointInput;
-                ap.render_input(frame);
+                ap.render_input(palette, frame);
             }
         }
 
         // Help
         if let FocusedBlock::Help = app.focused_block {
-            app.help.render(frame);
+            app.help.render(palette, frame);
         }
 
         // Notifications
         for (index, notification) in app.notifications.iter().enumerate() {
-            notification.render(index, frame);
+            notification.render(index, palette, frame);
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,10 +12,10 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         app.render(frame);
     } else {
         // App
-        app.adapter.render(frame, app.color_mode, app.focused_block);
+        app.adapter.render(frame, app.focused_block);
 
         if app.focused_block == FocusedBlock::AdapterInfos {
-            app.adapter.render_adapter(frame, app.color_mode);
+            app.adapter.render_adapter(frame);
         }
 
         // Auth Popup
@@ -34,7 +34,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
 
         // Help
         if let FocusedBlock::Help = app.focused_block {
-            app.help.render(frame, app.color_mode);
+            app.help.render(frame);
         }
 
         // Notifications


### PR DESCRIPTION
Planning to add Impala to a Raspberry Pi-based device with a small screen.
This PR adds a small-screen mode with a tabbed interface.

![Resizing Impala](https://github.com/user-attachments/assets/e023f19d-bca6-44d6-ae09-7fbe825b08a7)

Also:
* Add config file settings for auto-scan, color mode, and Unicode/ASCII.
* Fixes high CPU usage. The default 500us poll was hammering DBus and causing lag on Raspberry Pi. The new 50000us poll time does not bog down the system as much.
* Fixes terminal not resetting properly on exit.