### PR TITLE
feat: censor password with toggle keybind

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,7 @@ pub struct App {
     pub passkey_sender: Sender<String>,
     pub cancel_signal_sender: Sender<()>,
     pub passkey_input: Input,
+    pub show_password: bool,
     pub mode: Mode,
     pub selected_mode: Mode,
     pub current_mode: Mode,
@@ -113,6 +114,7 @@ impl App {
         let current_mode = adapter.device.mode.clone();
 
         let (passkey_sender, passkey_receiver) = async_channel::unbounded();
+        let show_password = false;
         let (cancel_signal_sender, cancel_signal_receiver) = async_channel::unbounded();
 
         let authentication_required = Arc::new(AtomicBool::new(false));
@@ -153,6 +155,7 @@ impl App {
             passkey_sender,
             cancel_signal_sender,
             passkey_input: Input::default(),
+            show_password,
             mode,
             selected_mode: Mode::Station,
             current_mode,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -60,6 +60,11 @@ pub async fn handle_key_events(
                 app.cancel_auth().await?;
                 app.focused_block = FocusedBlock::Device;
             }
+
+            KeyCode::Tab => {
+                app.show_password = !app.show_password;
+            }
+
             _ => {
                 app.passkey_input
                     .handle_event(&crossterm::event::Event::Key(key_event));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,8 +21,12 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         // Auth Popup
         if app.authentication_required.load(Ordering::Relaxed) {
             app.focused_block = FocusedBlock::AuthKey;
-            let censored_passkey = "*".repeat(app.passkey_input.value().len());
-            Auth.render(frame, &censored_passkey);
+            let censored_password = "*".repeat(app.passkey_input.value().len());
+            if !app.show_password {
+                Auth.render(frame, &censored_password);
+            } else {
+                Auth.render(frame, app.passkey_input.value());
+            }
         }
 
         // Access Point Popup

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,7 +21,8 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         // Auth Popup
         if app.authentication_required.load(Ordering::Relaxed) {
             app.focused_block = FocusedBlock::AuthKey;
-            Auth.render(frame, app.passkey_input.value());
+            let censored_passkey = "*".repeat(app.passkey_input.value().len());
+            Auth.render(frame, &censored_passkey);
         }
 
         // Access Point Popup


### PR DESCRIPTION
Addresses issue #29 

## Changes:
- Added a new boolean variable in `App` called `show_password` which manages the state of how the password should be displayed in the `passkey` field
- Added a new keybind `handler.rs` for AuthKey, 'Tab' to toggle the state of `show_password` variable
- Implementation of the censor done in `ui.rs` in the auth popup block