### PR TITLE
chore: fix many clippy lints

### DIFF
--- a/src/access_point.rs
+++ b/src/access_point.rs
@@ -222,7 +222,7 @@ impl AccessPoint {
                 self.connected_devices = diagnostic
                     .iter()
                     .map(|v| v["Address"].clone().trim_matches('"').to_string())
-                    .collect()
+                    .collect();
             }
         }
 
@@ -232,12 +232,12 @@ impl AccessPoint {
     pub async fn scan(&self, sender: UnboundedSender<Event>) -> AppResult<()> {
         let iwd_access_point = self.session.access_point().unwrap();
         match iwd_access_point.scan().await {
-            Ok(_) => Notification::send(
+            Ok(()) => Notification::send(
                 "Start Scanning".to_string(),
                 NotificationLevel::Info,
-                sender,
+                &sender,
             )?,
-            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?,
+            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?,
         }
 
         Ok(())
@@ -249,12 +249,12 @@ impl AccessPoint {
             .start(self.ssid.value(), self.psk.value())
             .await
         {
-            Ok(_) => Notification::send(
+            Ok(()) => Notification::send(
                 format!("AP Started\nSSID: {}", self.ssid.value()),
                 NotificationLevel::Info,
-                sender,
+                &sender,
             )?,
-            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?,
+            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?,
         }
         self.ap_start
             .store(false, std::sync::atomic::Ordering::Relaxed);
@@ -265,8 +265,10 @@ impl AccessPoint {
     pub async fn stop(&self, sender: UnboundedSender<Event>) -> AppResult<()> {
         let iwd_access_point = self.session.access_point().unwrap();
         match iwd_access_point.stop().await {
-            Ok(_) => Notification::send("AP Stopped".to_string(), NotificationLevel::Info, sender)?,
-            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?,
+            Ok(()) => {
+                Notification::send("AP Stopped".to_string(), NotificationLevel::Info, &sender)?
+            }
+            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?,
         }
 
         Ok(())

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -226,7 +226,7 @@ impl Adapter {
         let ap_frequency = match self.device.access_point.as_ref() {
             Some(ap) => {
                 if ap.has_started {
-                    format!("{:.2} GHz", (ap.frequency.unwrap() as f32 / 1000.0))
+                    format!("{:.2} GHz", (ap.frequency.unwrap() / 1000))
                 } else {
                     "-".to_string()
                 }
@@ -1034,14 +1034,14 @@ impl Adapter {
             rows.push(Row::new(vec![
                 Cell::from("model").style(Style::default().bold().yellow()),
                 Cell::from(model.clone()),
-            ]))
+            ]));
         }
 
         if let Some(vendor) = &self.vendor {
             rows.push(Row::new(vec![
                 Cell::from("vendor").style(Style::default().bold().yellow()),
                 Cell::from(vendor.clone()),
-            ]))
+            ]));
         }
 
         let widths = [Constraint::Length(20), Constraint::Fill(1)];

--- a/src/app.rs
+++ b/src/app.rs
@@ -80,7 +80,7 @@ pub async fn request_confirmation(
 
     r = rx_cancel.recv() => {
             match r {
-                Ok(_) => {
+                Ok(()) => {
                         Err(anyhow!("Operation Canceled").into())},
                 Err(_) => Err(anyhow!("Failed to receive cancel signal").into()),
             }
@@ -138,8 +138,7 @@ impl App {
 
         let color_mode = match terminal_light::luma() {
             Ok(luma) if luma > 0.6 => ColorMode::Light,
-            Ok(_) => ColorMode::Dark,
-            Err(_) => ColorMode::Dark,
+            Ok(_) | Err(_) => ColorMode::Dark,
         };
 
         Ok(Self {

--- a/src/device.rs
+++ b/src/device.rs
@@ -37,7 +37,7 @@ impl Device {
                     Notification::send(
                         e.to_string(),
                         crate::notification::NotificationLevel::Error,
-                        sender.clone(),
+                        &sender.clone(),
                     )?;
                     None
                 }
@@ -52,7 +52,7 @@ impl Device {
                     Notification::send(
                         e.to_string(),
                         crate::notification::NotificationLevel::Error,
-                        sender,
+                        &sender,
                     )?;
                     None
                 }
@@ -110,7 +110,7 @@ impl Device {
                                     Notification::send(
                                         e.to_string(),
                                         crate::notification::NotificationLevel::Error,
-                                        sender,
+                                        &sender,
                                     )?;
                                     None
                                 }
@@ -132,7 +132,7 @@ impl Device {
                                     Notification::send(
                                         e.to_string(),
                                         crate::notification::NotificationLevel::Error,
-                                        sender,
+                                        &sender,
                                     )?;
                                     None
                                 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -22,7 +22,7 @@ pub async fn handle_key_events(
             KeyCode::Char('q') => {
                 app.quit();
             }
-            KeyCode::Char('c') | KeyCode::Char('C') => {
+            KeyCode::Char('c' | 'C') => {
                 if key_event.modifiers == KeyModifiers::CONTROL {
                     app.quit();
                 }
@@ -113,7 +113,7 @@ pub async fn handle_key_events(
                 KeyCode::Char('q') => {
                     app.quit();
                 }
-                KeyCode::Char('c') | KeyCode::Char('C') => {
+                KeyCode::Char('c' | 'C') => {
                     if key_event.modifiers == KeyModifiers::CONTROL {
                         app.quit();
                     }
@@ -150,7 +150,7 @@ pub async fn handle_key_events(
                                 .as_mut()
                                 .unwrap()
                                 .scan(sender)
-                                .await?
+                                .await?;
                         }
                         Mode::Ap => {
                             app.adapter
@@ -159,10 +159,10 @@ pub async fn handle_key_events(
                                 .as_mut()
                                 .unwrap()
                                 .scan(sender)
-                                .await?
+                                .await?;
                         }
                         _ => {}
-                    };
+                    }
                 }
 
                 KeyCode::Tab => match app.adapter.device.mode {
@@ -201,12 +201,12 @@ pub async fn handle_key_events(
                             if let Some(ap) = &mut app.adapter.device.access_point {
                                 match ap.focused_section {
                                     APFocusedSection::SSID => {
-                                        ap.focused_section = APFocusedSection::PSK
+                                        ap.focused_section = APFocusedSection::PSK;
                                     }
                                     APFocusedSection::PSK => {
-                                        ap.focused_section = APFocusedSection::SSID
+                                        ap.focused_section = APFocusedSection::SSID;
                                     }
-                                };
+                                }
                             }
                         }
                         _ => {}
@@ -250,12 +250,12 @@ pub async fn handle_key_events(
                             if let Some(ap) = &mut app.adapter.device.access_point {
                                 match ap.focused_section {
                                     APFocusedSection::SSID => {
-                                        ap.focused_section = APFocusedSection::PSK
+                                        ap.focused_section = APFocusedSection::PSK;
                                     }
                                     APFocusedSection::PSK => {
-                                        ap.focused_section = APFocusedSection::SSID
+                                        ap.focused_section = APFocusedSection::SSID;
                                     }
-                                };
+                                }
                             }
                         }
                         _ => {}
@@ -278,14 +278,14 @@ pub async fn handle_key_events(
                                             Notification::send(
                                                 "Device Powered Off".to_string(),
                                                 crate::notification::NotificationLevel::Info,
-                                                sender.clone(),
+                                                &sender.clone(),
                                             )?;
                                         }
                                         Err(e) => {
                                             Notification::send(
                                                 e.to_string(),
                                                 crate::notification::NotificationLevel::Error,
-                                                sender.clone(),
+                                                &sender.clone(),
                                             )?;
                                         }
                                     }
@@ -296,14 +296,14 @@ pub async fn handle_key_events(
                                             Notification::send(
                                                 "Device Powered On".to_string(),
                                                 crate::notification::NotificationLevel::Info,
-                                                sender.clone(),
+                                                &sender.clone(),
                                             )?;
                                         }
                                         Err(e) => {
                                             Notification::send(
                                                 e.to_string(),
                                                 crate::notification::NotificationLevel::Error,
-                                                sender.clone(),
+                                                &sender.clone(),
                                             )?;
                                         }
                                     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -20,7 +20,7 @@ pub struct Help {
 }
 
 impl Help {
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: &Arc<Config>) -> Self {
         let mut state = TableState::new().with_offset(0);
         state.select(Some(0));
 
@@ -159,7 +159,7 @@ impl Help {
             .keys
             .iter()
             .map(|key| {
-                Row::new(vec![key.0.to_owned(), key.1.into()]).style(match color_mode {
+                Row::new(vec![key.0.clone(), key.1.into()]).style(match color_mode {
                     ColorMode::Dark => Style::default().fg(Color::White),
                     ColorMode::Light => Style::default().fg(Color::Black),
                 })

--- a/src/known_network.rs
+++ b/src/known_network.rs
@@ -42,14 +42,14 @@ impl KnownNetwork {
 
     pub async fn forget(&self, sender: UnboundedSender<Event>) -> AppResult<()> {
         if let Err(e) = self.n.forget().await {
-            Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?;
+            Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?;
             return Ok(());
         }
 
         Notification::send(
             "Network Removed".to_string(),
             NotificationLevel::Info,
-            sender,
+            &sender,
         )?;
         Ok(())
     }
@@ -57,28 +57,28 @@ impl KnownNetwork {
     pub async fn toggle_autoconnect(&self, sender: UnboundedSender<Event>) -> AppResult<()> {
         if self.is_autoconnect {
             match self.n.set_autoconnect(false).await {
-                Ok(_) => {
+                Ok(()) => {
                     Notification::send(
                         format!("Disable Autoconnect for: {}", self.name),
                         NotificationLevel::Info,
-                        sender.clone(),
+                        &sender.clone(),
                     )?;
                 }
                 Err(e) => {
-                    Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?;
+                    Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?;
                 }
             }
         } else {
             match self.n.set_autoconnect(true).await {
-                Ok(_) => {
+                Ok(()) => {
                     Notification::send(
                         format!("Enable Autoconnect for: {}", self.name),
                         NotificationLevel::Info,
-                        sender.clone(),
+                        &sender.clone(),
                     )?;
                 }
                 Err(e) => {
-                    Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?;
+                    Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> AppResult<()> {
 
     let config = Arc::new(Config::new());
 
-    let help = Help::new(config.clone());
+    let help = Help::new(&config.clone());
 
     let backend = CrosstermBackend::new(io::stdout());
     let terminal = Terminal::new(backend)?;
@@ -52,7 +52,7 @@ async fn main() -> AppResult<()> {
                     tui.events.sender.clone(),
                     config.clone(),
                 )
-                .await?
+                .await?;
             }
             Event::Notification(notification) => {
                 app.notifications.push(notification);

--- a/src/network.rs
+++ b/src/network.rs
@@ -43,20 +43,20 @@ impl Network {
 
     pub async fn connect(&self, sender: UnboundedSender<Event>) -> AppResult<()> {
         match self.n.connect().await {
-            Ok(_) => Notification::send(
+            Ok(()) => Notification::send(
                 format!("Connected to {}", self.name),
                 NotificationLevel::Info,
-                sender,
+                &sender,
             )?,
             Err(e) => {
                 if e.to_string().contains("net.connman.iwd.Aborted") {
                     Notification::send(
                         "Connection canceled".to_string(),
                         NotificationLevel::Info,
-                        sender,
-                    )?
+                        &sender,
+                    )?;
                 } else {
-                    Notification::send(e.to_string(), NotificationLevel::Error, sender)?
+                    Notification::send(e.to_string(), NotificationLevel::Error, &sender)?;
                 }
             }
         }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -37,8 +37,8 @@ impl Notification {
 
         text.extend(Text::from(self.message.as_str()));
 
-        let notification_height = text.height() as u16 + 2;
-        let notification_width = text.width() as u16 + 4;
+        let notification_height = u16::try_from(text.height()).expect("Could not cast tu u16") + 2;
+        let notification_width = u16::try_from(text.width()).expect("Could not cast tu u16") + 4;
 
         let block = Paragraph::new(text)
             .alignment(Alignment::Center)
@@ -52,7 +52,7 @@ impl Notification {
             );
 
         let area = notification_rect(
-            index as u16,
+            u16::try_from(index).expect("Could not cast tu u16"),
             notification_height,
             notification_width,
             frame.area(),
@@ -64,7 +64,7 @@ impl Notification {
     pub fn send(
         message: String,
         level: NotificationLevel,
-        sender: UnboundedSender<Event>,
+        sender: &UnboundedSender<Event>,
     ) -> AppResult<()> {
         let notif = Notification {
             message,

--- a/src/rfkill.rs
+++ b/src/rfkill.rs
@@ -20,11 +20,11 @@ pub fn check() -> AppResult<()> {
                 match state {
                     0 => {
                         eprintln!(
-                            r#"
+                            r"
 The wifi device is soft blocked
 Run the following command to unblock it
 $ sudo rfkill unblock wlan
-                    "#
+                    "
                         );
                         std::process::exit(1);
                     }

--- a/src/station.rs
+++ b/src/station.rs
@@ -115,7 +115,7 @@ impl Station {
         let connected_network = {
             if let Some(n) = iwd_station.connected_network().await? {
                 let network = Network::new(n.clone()).await?;
-                Some(network.to_owned())
+                Some(network.clone())
             } else {
                 None
             }
@@ -152,7 +152,17 @@ impl Station {
         self.state = state;
         self.is_scanning = is_scanning;
 
-        if self.new_networks.len() != new_networks.len() {
+        if self.new_networks.len() == new_networks.len() {
+            self.new_networks.iter_mut().for_each(|(net, signal)| {
+                let n = new_networks
+                    .iter()
+                    .find(|(refreshed_net, _signal)| refreshed_net.name == net.name);
+
+                if let Some((_, refreshed_signal)) = n {
+                    *signal = *refreshed_signal;
+                }
+            });
+        } else {
             let mut new_networks_state = TableState::default();
             if new_networks.is_empty() {
                 new_networks_state.select(None);
@@ -162,28 +172,9 @@ impl Station {
 
             self.new_networks_state = new_networks_state;
             self.new_networks = new_networks;
-        } else {
-            self.new_networks.iter_mut().for_each(|(net, signal)| {
-                let n = new_networks
-                    .iter()
-                    .find(|(refreshed_net, _signal)| refreshed_net.name == net.name);
-
-                if let Some((_, refreshed_signal)) = n {
-                    *signal = *refreshed_signal;
-                }
-            })
         }
 
-        if self.known_networks.len() != known_networks.len() {
-            let mut known_networks_state = TableState::default();
-            if known_networks.is_empty() {
-                known_networks_state.select(None);
-            } else {
-                known_networks_state.select(Some(0));
-            }
-            self.known_networks_state = known_networks_state;
-            self.known_networks = known_networks;
-        } else {
+        if self.known_networks.len() == known_networks.len() {
             self.known_networks.iter_mut().for_each(|(net, signal)| {
                 let n = known_networks
                     .iter()
@@ -194,7 +185,16 @@ impl Station {
                         refreshed_net.known_network.as_ref().unwrap().is_autoconnect;
                     *signal = *refreshed_signal;
                 }
-            })
+            });
+        } else {
+            let mut known_networks_state = TableState::default();
+            if known_networks.is_empty() {
+                known_networks_state.select(None);
+            } else {
+                known_networks_state.select(Some(0));
+            }
+            self.known_networks_state = known_networks_state;
+            self.known_networks = known_networks;
         }
 
         self.connected_network = connected_network;
@@ -211,12 +211,12 @@ impl Station {
     pub async fn scan(&self, sender: UnboundedSender<Event>) -> AppResult<()> {
         let iwd_station = self.session.station().unwrap();
         match iwd_station.scan().await {
-            Ok(_) => Notification::send(
+            Ok(()) => Notification::send(
                 "Start Scanning".to_string(),
                 NotificationLevel::Info,
-                sender,
+                &sender,
             )?,
-            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?,
+            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?,
         }
 
         Ok(())
@@ -225,15 +225,15 @@ impl Station {
     pub async fn disconnect(&self, sender: UnboundedSender<Event>) -> AppResult<()> {
         let iwd_station = self.session.station().unwrap();
         match iwd_station.disconnect().await {
-            Ok(_) => Notification::send(
+            Ok(()) => Notification::send(
                 format!(
                     "Disconnected from {}",
                     self.connected_network.as_ref().unwrap().name
                 ),
                 NotificationLevel::Info,
-                sender,
+                &sender,
             )?,
-            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, sender.clone())?,
+            Err(e) => Notification::send(e.to_string(), NotificationLevel::Error, &sender.clone())?,
         }
         Ok(())
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -22,10 +22,10 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         if app.authentication_required.load(Ordering::Relaxed) {
             app.focused_block = FocusedBlock::AuthKey;
             let censored_password = "*".repeat(app.passkey_input.value().len());
-            if !app.show_password {
-                Auth.render(frame, &censored_password);
-            } else {
+            if app.show_password {
                 Auth.render(frame, app.passkey_input.value());
+            } else {
+                Auth.render(frame, &censored_password);
             }
         }
 


### PR DESCRIPTION
Poking around your repo got me in the mood of fixing some clippy lints, so I ran

```bash
> cargo clippy --fix --allow-dirty -- -D warnings -W clippy::pedantic -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::too_many_lines
```
and fixed everything remaining except those two:
```rust
    Checking impala v0.2.4 (/home/vuimuich/Git/impala)
warning: wildcard matches only a single variant and will also match any future added variants
   --> src/access_point.rs:164:13
    |
164 |             _ => Text::from("  SSID name"),
    |             ^ help: try: `APFocusedSection::PSK`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants
    = note: `-D clippy::match-wildcard-for-single-variants` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_wildcard_for_single_variants)]`

warning: wildcard matches only a single variant and will also match any future added variants
   --> src/access_point.rs:169:13
    |
169 |             _ => Text::from("  SSID password"),
    |             ^ help: try: `APFocusedSection::SSID`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants

warning: `impala` (lib) generated 2 warnings
warning: `impala` (lib test) generated 2 warnings (2 duplicates)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.30s
```
