### PR TITLE
fix: reset terminal on panic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 use std::{
     error::Error,
-    process::{self, exit},
+    process::exit,
     sync::{Arc, atomic::AtomicBool},
 };
 use tokio::sync::mpsc::UnboundedSender;


### PR DESCRIPTION
Addresses #58.
Removed ```std::process::exit(1)``` in favor of returning ```Err(e)```. 