### PR TITLE
Binds <Esc> to quit in contexts where q or ctrl+c is accepted as quit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,7 @@ This will produce an executable file at `target/release/impala` that you can cop
 
 `esc`: Dismiss the different pop-ups.
 
-`q` or `ctrl+c` or `Esc`: Quit the app.
+`q` or `ctrl+c`: Quit the app. (Note: `<Esc>` can also quit if `esc_quit = true` is set in config)
 
 ### Device
 
@@ -103,6 +103,7 @@ Keybindings can be customized in the config file `$HOME/.config/impala/config.to
 
 switch = "r"
 mode = "station"
+esc_quit = false  # Set to true to enable Esc key to quit the app
 
 [device]
 infos = "i"

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,9 @@ pub struct Config {
     #[serde(default = "default_device_mode")]
     pub mode: String,
 
+    #[serde(default = "default_esc_quit")]
+    pub esc_quit: bool,
+
     #[serde(default)]
     pub device: Device,
 
@@ -27,6 +30,10 @@ fn default_switch_mode() -> char {
 
 fn default_device_mode() -> String {
     "station".to_string()
+}
+
+fn default_esc_quit() -> bool {
+    false
 }
 
 // Device

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -123,7 +123,10 @@ pub async fn handle_key_events(
 ) -> Result<()> {
     if app.reset.enable {
         match key_event.code {
-            KeyCode::Char('q') | KeyCode::Esc => {
+            KeyCode::Char('q') => {
+                app.quit();
+            }
+            KeyCode::Esc if app.config.esc_quit => {
                 app.quit();
             }
             KeyCode::Char('c' | 'C') => {
@@ -162,7 +165,10 @@ pub async fn handle_key_events(
             }
 
             FocusedBlock::Device => match key_event.code {
-                KeyCode::Char('q') | KeyCode::Esc => {
+                KeyCode::Char('q') => {
+                    app.quit();
+                }
+                KeyCode::Esc if app.config.esc_quit => {
                     app.quit();
                 }
 
@@ -303,7 +309,10 @@ pub async fn handle_key_events(
                     }
                     _ => {
                         match key_event.code {
-                            KeyCode::Char('q') | KeyCode::Esc => {
+                            KeyCode::Char('q') => {
+                                app.quit();
+                            }
+                            KeyCode::Esc if app.config.esc_quit => {
                                 app.quit();
                             }
 
@@ -522,7 +531,10 @@ pub async fn handle_key_events(
                     }
                     _ => {
                         match key_event.code {
-                            KeyCode::Char('q') | KeyCode::Esc => {
+                            KeyCode::Char('q') => {
+                                app.quit();
+                            }
+                            KeyCode::Esc if app.config.esc_quit => {
                                 app.quit();
                             }
 


### PR DESCRIPTION
@pythops If you're okay with Esc [as a way to quit in bluetui](https://github.com/pythops/bluetui/pull/98), this does the same for Impala.