### PR TITLE
Add ASCII-only mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub mod reset;
 
 pub mod agent;
 
+pub mod symbols;
+
 pub fn iwd_network_name(name: &str) -> String {
     match name
         .chars()

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,0 +1,46 @@
+use std::sync::OnceLock;
+
+static SYMBOL_RENDERER: OnceLock<fn(Symbol) -> &'static str> = OnceLock::new();
+
+pub enum Symbol {
+    Up,
+    Down,
+    Left,
+    Right,
+    Tab,
+    Enter,
+    Spacebar,
+    SignalStrength(u8),
+    Esc,
+}
+
+pub fn render_unicode(sym: Symbol) -> &'static str {
+    match sym {
+        Symbol::Up => "↑",
+        Symbol::Esc => "󱊷",
+    }
+}
+
+pub fn render_ascii(sym: Symbol) -> &'static str {
+    match sym {
+        Symbol::Up => "ARROW_UP",
+        Symbol::Esc => "ESC",
+    }
+}
+
+pub fn render(sym: Symbol) -> &'static str {
+    SYMBOL_RENDERER
+        .get()
+        .expect("symbol renderer not initialized")(sym)
+}
+
+pub fn init_renderer(use_unicode: bool) {
+    let renderer = if use_unicode {
+        render_unicode
+    } else {
+        render_ascii
+    };
+    SYMBOL_RENDERER
+        .set(renderer)
+        .expect("symbol renderer already initialized");
+}


### PR DESCRIPTION
Trying to implement a more generic symbol/emoji lookup by creating an enum `Symbol` and a global `SYMBOL_RENDERER` that is a `OnceLock` that is initialized on startup, and holds a function pointer for how to resolve `Symbol` to `&'static str`.

Do you think that this is a reasonable approach?

Fixes #26.
