### PR TITLE
fix(ttls): correct Phase 2 method names for iwd compatibility

### DIFF
--- a/src/mode/station/auth/entreprise/ttls.rs
+++ b/src/mode/station/auth/entreprise/ttls.rs
@@ -21,9 +21,13 @@ use crate::{
 enum Phase2Method {
     #[default]
     MSCHAPV2,
+    #[strum(serialize = "Tunneled-CHAP")]
     TunneledCHAP,
+    #[strum(serialize = "Tunneled-MSCHAP")]
     TunneledMSCHAP,
+    #[strum(serialize = "Tunneled-MSCHAPv2")]
     TunneledMSCHAPv2,
+    #[strum(serialize = "Tunneled-PAP")]
     TunneledPAP,
 }
 


### PR DESCRIPTION
This PR updates the EAP-TTLS Phase 2 method names to ensure full compatibility with `iwd` configuration requirements. 

### Changes
- Standardized method names (PAP, CHAP, MSCHAP, MSCHAPv2) to follow the `Tunneled-` naming convention.
- Synchronized values with the official `iwd.network` specifications.
- Verified that the corrected strings resolve authentication failures in TTLS/PAP environments.

Closes #127 