### PR TITLE
feat: add h/l nav keys in addition to tab

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -383,8 +383,7 @@ pub async fn handle_key_events(
                             {
                                 app.reset.enable = true;
                             }
-
-                            KeyCode::Tab => match app.focused_block {
+                            KeyCode::Tab | KeyCode::Char('l') => match app.focused_block {
                                 FocusedBlock::Device => {
                                     app.focused_block = FocusedBlock::KnownNetworks;
                                 }
@@ -396,7 +395,7 @@ pub async fn handle_key_events(
                                 }
                                 _ => {}
                             },
-                            KeyCode::BackTab => match app.focused_block {
+                            KeyCode::BackTab | KeyCode::Char('h') => match app.focused_block {
                                 FocusedBlock::Device => {
                                     app.focused_block = FocusedBlock::NewNetworks;
                                 }
@@ -690,24 +689,26 @@ pub async fn handle_key_events(
                                 app.reset.enable = true;
                             }
 
-                            KeyCode::Tab => match app.focused_block {
-                                FocusedBlock::Device => {
-                                    app.focused_block = FocusedBlock::AccessPoint;
-                                }
-                                FocusedBlock::AccessPoint => {
-                                    if ap.connected_devices.is_empty() {
-                                        app.focused_block = FocusedBlock::Device;
-                                    } else {
-                                        app.focused_block =
-                                            FocusedBlock::AccessPointConnectedDevices;
+                            KeyCode::Tab | KeyCode::Char('h') | KeyCode::Char('l') => {
+                                match app.focused_block {
+                                    FocusedBlock::Device => {
+                                        app.focused_block = FocusedBlock::AccessPoint;
                                     }
-                                }
-                                FocusedBlock::AccessPointConnectedDevices => {
-                                    app.focused_block = FocusedBlock::Device;
-                                }
+                                    FocusedBlock::AccessPoint => {
+                                        if ap.connected_devices.is_empty() {
+                                            app.focused_block = FocusedBlock::Device;
+                                        } else {
+                                            app.focused_block =
+                                                FocusedBlock::AccessPointConnectedDevices;
+                                        }
+                                    }
+                                    FocusedBlock::AccessPointConnectedDevices => {
+                                        app.focused_block = FocusedBlock::Device;
+                                    }
 
-                                _ => {}
-                            },
+                                    _ => {}
+                                }
+                            }
 
                             _ => {
                                 if app.focused_block == FocusedBlock::Device {


### PR DESCRIPTION
This PR implements the requested h and l navigation keys.

* Added h (left/back) and l (right/forward) navigation to both Station and AP modes.
* In views with only two focusable blocks(ap mode), both keys toggle between them to maintain muscle memory.
* Navigation is explicitly excluded from text input areas (like SSID/PSK input) to prevent conflicts with typing.

Closes #129 