### PR TITLE
Fix AP input popup flow

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -634,7 +634,7 @@ pub async fn handle_key_events(
                     FocusedBlock::AccessPointInput => match key_event.code {
                         KeyCode::Enter => {
                             ap.start(sender.clone()).await?;
-                            app.focused_block = FocusedBlock::Device;
+                            app.focused_block = FocusedBlock::AccessPoint;
                         }
 
                         KeyCode::Esc => {
@@ -708,6 +708,20 @@ pub async fn handle_key_events(
 
                                 _ => {}
                             },
+
+                            KeyCode::Char(c) if c == config.ap.start => {
+                                if app.focused_block == FocusedBlock::AccessPoint {
+                                    ap.ap_start
+                                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                                    app.focused_block = FocusedBlock::AccessPointInput;
+                                }
+                            }
+
+                            KeyCode::Char(c) if c == config.ap.stop => {
+                                if app.focused_block == FocusedBlock::AccessPoint {
+                                    ap.stop(sender.clone()).await?;
+                                }
+                            }
 
                             _ => {
                                 if app.focused_block == FocusedBlock::Device {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,6 +23,9 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                 Mode::Ap => {
                     if let Some(ap) = &mut app.device.ap {
                         ap.render(frame, app.focused_block, &device, app.config.clone());
+                        if app.focused_block == FocusedBlock::AccessPointInput {
+                            ap.render_input(frame);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #145

AP mode had two issues in the access point startup flow:

- pressing `n` did not trigger the configured AP start path from the AP pane
- once the input flow became active, the SSID/password popup was not rendered, so the form worked but stayed invisible

This change wires the AP start/stop keybindings into the AP-mode handler and renders the AP input popup when `FocusedBlock::AccessPointInput` is active.

Validation:
- `cargo build`
- tested AP mode locally
- confirmed `n` shows the popup
- entered SSID/passphrase and started an AP successfully